### PR TITLE
Add Jaqal export functionality for quantum circuits

### DIFF
--- a/examples/jaqal_export_demo.py
+++ b/examples/jaqal_export_demo.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+"""
+Demo script showing how to export hybridlane/PennyLane circuits to Jaqal format.
+"""
+
+import pennylane as qml
+from hybridlane.export import to_jaqal
+
+
+def bell_state_example():
+    """Create and export a Bell state preparation circuit."""
+    print("=" * 60)
+    print("Bell State Preparation Circuit")
+    print("=" * 60)
+    
+    # Create a simple Bell state circuit
+    dev = qml.device("default.qubit", wires=2)
+    
+    @qml.qnode(dev)
+    def bell_circuit():
+        qml.Hadamard(wires=0)
+        qml.CNOT(wires=[0, 1])
+        return qml.probs(wires=[0, 1])
+    
+    # Export to Jaqal
+    jaqal_code = to_jaqal(bell_circuit)
+    print(jaqal_code)
+    print()
+
+
+def ghz_state_example():
+    """Create and export a GHZ state preparation circuit."""
+    print("=" * 60)
+    print("GHZ State Preparation Circuit")
+    print("=" * 60)
+    
+    # Create a GHZ state circuit
+    dev = qml.device("default.qubit", wires=3)
+    
+    @qml.qnode(dev)
+    def ghz_circuit():
+        qml.Hadamard(wires=0)
+        qml.CNOT(wires=[0, 1])
+        qml.CNOT(wires=[1, 2])
+        return qml.probs(wires=[0, 1, 2])
+    
+    # Export to Jaqal
+    jaqal_code = to_jaqal(ghz_circuit)
+    print(jaqal_code)
+    print()
+
+
+def rotation_example():
+    """Create and export a circuit with rotation gates."""
+    print("=" * 60)
+    print("Rotation Gates Example")
+    print("=" * 60)
+    
+    # Create a circuit with various rotations
+    dev = qml.device("default.qubit", wires=2)
+    
+    @qml.qnode(dev)
+    def rotation_circuit():
+        qml.RX(0.5, wires=0)
+        qml.RY(1.0, wires=0)
+        qml.RZ(1.5, wires=0)
+        qml.RX(0.7, wires=1)
+        qml.CZ(wires=[0, 1])
+        return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
+    
+    # Export to Jaqal
+    jaqal_code = to_jaqal(rotation_circuit)
+    print(jaqal_code)
+    print()
+
+
+def main():
+    """Run all examples."""
+    print("\nHybridlane to Jaqal Export Examples\n")
+    
+    bell_state_example()
+    ghz_state_example()
+    rotation_example()
+    
+    print("=" * 60)
+    print("Export complete!")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/jaqal_hybrid_demo.py
+++ b/examples/jaqal_hybrid_demo.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+"""
+Demo showing hybridlane-specific CV and hybrid CV-DV operations in Jaqal export.
+
+Since Jaqal is designed for trapped-ion (discrete variable) systems, continuous
+variable and hybrid operations generate placeholder comments indicating future support.
+"""
+
+import pennylane as qml
+import hybridlane as hqml
+from hybridlane.export import to_jaqal
+
+
+def hybrid_cv_dv_example():
+    """Demonstrate a hybrid CV-DV circuit with placeholders."""
+    print("=" * 60)
+    print("Hybrid CV-DV Circuit Example")
+    print("=" * 60)
+    print("\nThis circuit mixes standard DV gates with CV and hybrid operations.")
+    print("CV and hybrid operations will show as placeholders in Jaqal.\n")
+    
+    # Use a tape to avoid device restrictions
+    with qml.tape.QuantumTape() as tape:
+        # Standard quantum gates (fully supported)
+        qml.Hadamard(wires=0)
+        qml.RY(0.5, wires=1)
+        
+        # CV operations (placeholders)
+        hqml.TwoModeSum(1.0, wires=[2, 3])
+        hqml.ModeSwap(wires=[3, 4])
+        hqml.Fourier(wires=2)
+        
+        # Hybrid CV-DV operations (placeholders)
+        hqml.JaynesCummings(0.8, 0.3, wires=[0, 2])  # Qubit-cavity interaction
+        hqml.ConditionalDisplacement(1.5, 0.2, wires=[3, 1])  # Conditional displacement
+        hqml.Rabi(2.0, wires=[1, 4])  # Rabi interaction
+        
+        # More standard gates
+        qml.CNOT(wires=[0, 1])
+        qml.CZ(wires=[1, 0])
+        
+        # Conditional operations (placeholders)
+        hqml.ConditionalRotation(0.7, wires=[0, 2])
+        hqml.ConditionalBeamsplitter(0.5, 0.2, wires=[1, 3, 4])
+        
+        qml.probs(wires=[0, 1])
+    
+    # Export to Jaqal
+    jaqal_code = to_jaqal(tape)
+    print(jaqal_code)
+    print()
+
+
+def selective_operations_example():
+    """Demonstrate selective and conditional operations."""
+    print("=" * 60)
+    print("Selective Operations Example")
+    print("=" * 60)
+    print("\nThese operations perform qubit rotations based on cavity state.\n")
+    
+    with qml.tape.QuantumTape() as tape:
+        # Prepare initial state
+        qml.RX(0.3, wires=0)
+        
+        # Selective operations based on Fock state
+        hqml.SelectiveQubitRotation(0.5, 0.2, n=1, wires=[0, 1])  # Rotate if n=1
+        hqml.SelectiveNumberArbitraryPhase(1.0, n=2, wires=[0, 1])  # Phase if n=2
+        
+        # Anti-Jaynes-Cummings (Blue sideband)
+        hqml.AntiJaynesCummings(0.4, 0.1, wires=[0, 1])
+        
+        # Conditional operations
+        hqml.ConditionalParity(wires=[0, 1])
+        hqml.ConditionalTwoModeSum(0.8, wires=[0, 1, 2])
+        hqml.ConditionalTwoModeSqueezing(0.3, 0.1, wires=[0, 1, 2])
+        
+        qml.expval(qml.PauliZ(0))
+    
+    jaqal_code = to_jaqal(tape)
+    print(jaqal_code)
+    print()
+
+
+def main():
+    """Run all examples."""
+    print("\n" + "=" * 60)
+    print("Hybridlane to Jaqal Export - CV/Hybrid Operations Demo")
+    print("=" * 60)
+    print("\nNOTE: Jaqal is designed for trapped-ion quantum computers which")
+    print("are discrete variable (DV) systems. Continuous variable (CV) and")
+    print("hybrid CV-DV operations are shown as placeholders with comments")
+    print("indicating that support is coming soon.\n")
+    
+    hybrid_cv_dv_example()
+    selective_operations_example()
+    
+    print("=" * 60)
+    print("Export complete!")
+    print("\nThe placeholder comments indicate where future compilation")
+    print("strategies will be implemented to decompose CV and hybrid")
+    print("operations into trapped-ion native gates.")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/hybridlane/__init__.py
+++ b/src/hybridlane/__init__.py
@@ -1,3 +1,3 @@
-from . import sa, transforms
+from . import export, sa, transforms
 from .measurements import expval, sample, var
 from .ops import *

--- a/src/hybridlane/export/README.md
+++ b/src/hybridlane/export/README.md
@@ -1,0 +1,143 @@
+# Hybridlane Jaqal Export
+
+This module provides functionality to export hybridlane/PennyLane quantum circuits to Jaqal (Just Another Quantum Assembly Language) format, which is used for trapped-ion quantum computers.
+
+## Features
+
+### Supported Operations
+
+The following standard quantum gates are fully supported and translated to native Jaqal operations:
+
+- **Single-qubit gates**: RX, RY, RZ, Pauli-X/Y/Z, Hadamard
+- **Two-qubit gates**: CNOT, CZ (decomposed using Mølmer-Sørensen gates)
+
+### Placeholder Support for Hybridlane Operations
+
+Since Jaqal is designed for trapped-ion (discrete variable) systems, the following hybridlane-specific operations generate placeholder comments indicating future support:
+
+#### Continuous Variable (CV) Operations
+- `TwoModeSum`
+- `ModeSwap`
+- `Fourier`
+- `FockStateProjector`
+- `NumberOperator`
+- `QuadOperator`, `QuadX`, `QuadP`
+
+#### Hybrid CV-DV Operations
+- `JaynesCummings` / `AntiJaynesCummings`
+- `ConditionalDisplacement`
+- `ConditionalBeamsplitter`
+- `ConditionalRotation`
+- `ConditionalParity`
+- `ConditionalTwoModeSqueezing`
+- `ConditionalTwoModeSum`
+- `Rabi`
+- `SelectiveQubitRotation`
+- `SelectiveNumberArbitraryPhase`
+
+## Usage
+
+### Basic Example
+
+```python
+import pennylane as qml
+from hybridlane.export import to_jaqal
+
+# Create a quantum circuit
+dev = qml.device("default.qubit", wires=2)
+
+@qml.qnode(dev)
+def bell_circuit():
+    qml.Hadamard(wires=0)
+    qml.CNOT(wires=[0, 1])
+    return qml.probs(wires=[0, 1])
+
+# Export to Jaqal
+jaqal_code = to_jaqal(bell_circuit)
+print(jaqal_code)
+```
+
+### Working with Tapes
+
+You can also export quantum tapes directly:
+
+```python
+with qml.tape.QuantumTape() as tape:
+    qml.RX(0.5, wires=0)
+    qml.RY(1.0, wires=1)
+    qml.CNOT(wires=[0, 1])
+    qml.expval(qml.PauliZ(0))
+
+jaqal_code = to_jaqal(tape)
+```
+
+### Hybrid CV-DV Circuits
+
+For circuits containing hybridlane-specific operations:
+
+```python
+import hybridlane as hqml
+
+with qml.tape.QuantumTape() as tape:
+    # Standard gates (fully supported)
+    qml.Hadamard(wires=0)
+    
+    # CV operation (placeholder)
+    hqml.TwoModeSum(1.0, wires=[1, 2])
+    
+    # Hybrid operation (placeholder)
+    hqml.JaynesCummings(0.8, 0.3, wires=[0, 1])
+    
+    qml.probs(wires=[0, 1])
+
+jaqal_code = to_jaqal(tape)
+# CV and hybrid operations will appear as comments in the output
+```
+
+## Output Format
+
+The generated Jaqal code follows the standard format:
+
+```jaqal
+// Generated from hybridlane circuit
+// Number of qubits: N
+
+register q[N]
+
+{
+    prepare_all
+    // Gate operations
+    measure_all
+}
+```
+
+## Gate Decompositions
+
+- **Hadamard**: Decomposed into Ry(π/2) and Rz(π)
+- **CNOT**: Decomposed using Mølmer-Sørensen (MS) gates and single-qubit rotations
+- **CZ**: Decomposed using MS gates and single-qubit rotations
+- **Pauli gates**: Converted to rotations by π
+
+## Future Work
+
+The placeholder system for CV and hybrid operations provides a clear roadmap for future development:
+
+1. **CV Operation Compilation**: Develop strategies to compile continuous variable operations into trapped-ion native gates
+2. **Hybrid Operation Decomposition**: Implement decomposition schemes for hybrid CV-DV operations
+3. **Optimization**: Add circuit optimization passes specific to trapped-ion architectures
+4. **Error Handling**: Implement more sophisticated error handling for unsupported operations
+
+## Testing
+
+Run the test suite:
+
+```bash
+pytest test/export/test_jaqal.py
+pytest test/export/test_hybridlane_ops_jaqal.py
+```
+
+## Examples
+
+See the `examples/` directory for complete examples:
+- `jaqal_export_demo.py`: Basic export functionality
+- `jaqal_hybrid_demo.py`: Hybrid CV-DV circuits with placeholders

--- a/src/hybridlane/export/__init__.py
+++ b/src/hybridlane/export/__init__.py
@@ -1,0 +1,3 @@
+from .jaqal import to_jaqal
+
+__all__ = ["to_jaqal"]

--- a/src/hybridlane/export/jaqal.py
+++ b/src/hybridlane/export/jaqal.py
@@ -1,0 +1,255 @@
+"""Export hybridlane circuits to Jaqal quantum assembly language."""
+
+import pennylane as qml
+from typing import Optional, Dict, Any, List
+from dataclasses import dataclass
+from enum import Enum
+
+
+class JaqalGateType(Enum):
+    """Standard Jaqal gate types."""
+    PREPARE = "prepare_all"
+    MEASURE = "measure_all"
+    RX = "Rx"
+    RY = "Ry"
+    RZ = "Rz"
+    MS = "MS"  # Molmer-Sorensen gate
+    SXX = "Sxx"  # XX gate
+
+
+@dataclass
+class JaqalInstruction:
+    """Represents a single Jaqal instruction."""
+    gate_name: str
+    qubits: List[int]
+    parameters: List[float] = None
+    
+    def to_jaqal(self) -> str:
+        """Convert to Jaqal syntax."""
+        # Handle comment lines
+        if self.gate_name.startswith("//"):
+            return self.gate_name
+        
+        if self.parameters:
+            params_str = " ".join(str(p) for p in self.parameters)
+            qubits_str = " ".join(f"q[{q}]" for q in self.qubits)
+            return f"{self.gate_name} {params_str} {qubits_str}"
+        else:
+            if self.qubits:
+                qubits_str = " ".join(f"q[{q}]" for q in self.qubits)
+                return f"{self.gate_name} {qubits_str}"
+            else:
+                return self.gate_name
+
+
+class HybridlaneToJaqalTranslator:
+    """Translates hybridlane/PennyLane circuits to Jaqal."""
+    
+    def __init__(self, num_qubits: Optional[int] = None):
+        self.num_qubits = num_qubits
+        self.instructions: List[JaqalInstruction] = []
+        self.gate_map = self._initialize_gate_map()
+    
+    def _initialize_gate_map(self) -> Dict[str, callable]:
+        """Initialize mapping from PennyLane gates to Jaqal instructions."""
+        return {
+            # Standard quantum gates (supported)
+            "PauliX": self._pauli_x_to_jaqal,
+            "PauliY": self._pauli_y_to_jaqal,
+            "PauliZ": self._pauli_z_to_jaqal,
+            "RX": self._rx_to_jaqal,
+            "RY": self._ry_to_jaqal,
+            "RZ": self._rz_to_jaqal,
+            "Hadamard": self._hadamard_to_jaqal,
+            "CNOT": self._cnot_to_jaqal,
+            "CZ": self._cz_to_jaqal,
+            
+            # Hybridlane CV operations (placeholders - support coming soon)
+            "FockStateProjector": self._cv_placeholder,
+            "Fourier": self._cv_placeholder,
+            "ModeSwap": self._cv_placeholder,
+            "NumberOperator": self._cv_placeholder,
+            "QuadOperator": self._cv_placeholder,
+            "QuadP": self._cv_placeholder,
+            "QuadX": self._cv_placeholder,
+            "TwoModeSum": self._cv_placeholder,
+            
+            # Hybridlane hybrid CV-DV operations (placeholders - support coming soon)
+            "AntiJaynesCummings": self._hybrid_placeholder,
+            "ConditionalBeamsplitter": self._hybrid_placeholder,
+            "ConditionalDisplacement": self._hybrid_placeholder,
+            "ConditionalParity": self._hybrid_placeholder,
+            "ConditionalRotation": self._hybrid_placeholder,
+            "ConditionalTwoModeSqueezing": self._hybrid_placeholder,
+            "ConditionalTwoModeSum": self._hybrid_placeholder,
+            "Hybrid": self._hybrid_placeholder,
+            "JaynesCummings": self._hybrid_placeholder,
+            "Rabi": self._hybrid_placeholder,
+            "SelectiveNumberArbitraryPhase": self._hybrid_placeholder,
+            "SelectiveQubitRotation": self._hybrid_placeholder,
+        }
+    
+    def _pauli_x_to_jaqal(self, op) -> List[JaqalInstruction]:
+        """Convert Pauli-X to Jaqal Rx(pi)."""
+        return [JaqalInstruction(JaqalGateType.RX.value, [op.wires[0]], [3.14159265359])]
+    
+    def _pauli_y_to_jaqal(self, op) -> List[JaqalInstruction]:
+        """Convert Pauli-Y to Jaqal Ry(pi)."""
+        return [JaqalInstruction(JaqalGateType.RY.value, [op.wires[0]], [3.14159265359])]
+    
+    def _pauli_z_to_jaqal(self, op) -> List[JaqalInstruction]:
+        """Convert Pauli-Z to Jaqal Rz(pi)."""
+        return [JaqalInstruction(JaqalGateType.RZ.value, [op.wires[0]], [3.14159265359])]
+    
+    def _rx_to_jaqal(self, op) -> List[JaqalInstruction]:
+        """Convert RX rotation to Jaqal."""
+        return [JaqalInstruction(JaqalGateType.RX.value, [op.wires[0]], [op.parameters[0]])]
+    
+    def _ry_to_jaqal(self, op) -> List[JaqalInstruction]:
+        """Convert RY rotation to Jaqal."""
+        return [JaqalInstruction(JaqalGateType.RY.value, [op.wires[0]], [op.parameters[0]])]
+    
+    def _rz_to_jaqal(self, op) -> List[JaqalInstruction]:
+        """Convert RZ rotation to Jaqal."""
+        return [JaqalInstruction(JaqalGateType.RZ.value, [op.wires[0]], [op.parameters[0]])]
+    
+    def _hadamard_to_jaqal(self, op) -> List[JaqalInstruction]:
+        """Convert Hadamard to Jaqal using Ry and Rz rotations."""
+        wire = op.wires[0]
+        return [
+            JaqalInstruction(JaqalGateType.RY.value, [wire], [1.5707963268]),  # pi/2
+            JaqalInstruction(JaqalGateType.RZ.value, [wire], [3.14159265359]),  # pi
+        ]
+    
+    def _cnot_to_jaqal(self, op) -> List[JaqalInstruction]:
+        """Convert CNOT to Jaqal using MS gates and single-qubit rotations."""
+        control, target = op.wires[0], op.wires[1]
+        pi_2 = 1.5707963268
+        pi = 3.14159265359
+        
+        return [
+            JaqalInstruction(JaqalGateType.RY.value, [target], [pi_2]),
+            JaqalInstruction(JaqalGateType.MS.value, [control, target], [0, pi_2]),
+            JaqalInstruction(JaqalGateType.RX.value, [control], [-pi_2]),
+            JaqalInstruction(JaqalGateType.RX.value, [target], [-pi_2]),
+            JaqalInstruction(JaqalGateType.RY.value, [target], [-pi_2]),
+        ]
+    
+    def _cz_to_jaqal(self, op) -> List[JaqalInstruction]:
+        """Convert CZ to Jaqal using MS gates and single-qubit rotations."""
+        q1, q2 = op.wires[0], op.wires[1]
+        pi_2 = 1.5707963268
+        pi = 3.14159265359
+        
+        return [
+            JaqalInstruction(JaqalGateType.RY.value, [q2], [pi_2]),
+            JaqalInstruction(JaqalGateType.MS.value, [q1, q2], [0, pi_2]),
+            JaqalInstruction(JaqalGateType.RX.value, [q1], [-pi_2]),
+            JaqalInstruction(JaqalGateType.RX.value, [q2], [-pi_2]),
+            JaqalInstruction(JaqalGateType.RY.value, [q2], [-pi_2]),
+            JaqalInstruction(JaqalGateType.RZ.value, [q2], [pi]),
+        ]
+    
+    def _cv_placeholder(self, op) -> List[JaqalInstruction]:
+        """Placeholder for continuous variable operations.
+        
+        CV operations are not natively supported in Jaqal (trapped-ion architecture).
+        Support for CV operation emulation/compilation coming soon.
+        """
+        op_name = op.name
+        wires = list(op.wires)
+        # Return a comment instruction placeholder
+        comment = f"// CV Operation: {op_name} on modes {wires} - Support coming soon"
+        return [JaqalInstruction(comment, [], [])]
+    
+    def _hybrid_placeholder(self, op) -> List[JaqalInstruction]:
+        """Placeholder for hybrid CV-DV operations.
+        
+        Hybrid CV-DV operations are not natively supported in Jaqal (trapped-ion architecture).
+        Support for hybrid operation decomposition/compilation coming soon.
+        """
+        op_name = op.name
+        wires = list(op.wires)
+        # Return a comment instruction placeholder
+        comment = f"// Hybrid CV-DV Operation: {op_name} on wires/modes {wires} - Support coming soon"
+        return [JaqalInstruction(comment, [], [])]
+    
+    def translate_operation(self, op):
+        """Translate a single PennyLane operation to Jaqal instructions."""
+        op_name = op.name
+        
+        if op_name in self.gate_map:
+            return self.gate_map[op_name](op)
+        else:
+            raise NotImplementedError(f"Gate '{op_name}' not yet supported for Jaqal export")
+    
+    def translate_circuit(self, tape: qml.tape.QuantumTape) -> str:
+        """Translate a PennyLane tape to Jaqal program."""
+        self.instructions = []
+        
+        # Determine number of qubits
+        if self.num_qubits is None:
+            self.num_qubits = len(tape.wires)
+        
+        # Add preparation
+        self.instructions.append(JaqalInstruction(JaqalGateType.PREPARE.value, [], []))
+        
+        # Translate operations
+        for op in tape.operations:
+            jaqal_ops = self.translate_operation(op)
+            self.instructions.extend(jaqal_ops)
+        
+        # Add measurements if needed
+        if tape.measurements:
+            self.instructions.append(JaqalInstruction(JaqalGateType.MEASURE.value, [], []))
+        
+        # Generate Jaqal code
+        return self.generate_jaqal_code()
+    
+    def generate_jaqal_code(self) -> str:
+        """Generate the final Jaqal code."""
+        lines = []
+        
+        # Header
+        lines.append(f"// Generated from hybridlane circuit")
+        lines.append(f"// Number of qubits: {self.num_qubits}")
+        lines.append("")
+        
+        # Register declaration
+        lines.append(f"register q[{self.num_qubits}]")
+        lines.append("")
+        
+        # Main circuit block
+        lines.append("{")
+        for instruction in self.instructions:
+            lines.append(f"    {instruction.to_jaqal()}")
+        lines.append("}")
+        
+        return "\n".join(lines)
+
+
+def to_jaqal(qnode_or_tape, *args, **kwargs) -> str:
+    """
+    Export a hybridlane/PennyLane circuit to Jaqal format.
+    
+    Args:
+        qnode_or_tape: Either a QNode or a QuantumTape to export
+        *args: Arguments to pass to QNode if applicable
+        **kwargs: Keyword arguments to pass to QNode if applicable
+    
+    Returns:
+        str: Jaqal program as a string
+    """
+    # Handle QNode
+    if isinstance(qnode_or_tape, qml.QNode):
+        # Execute the QNode to get the tape
+        qnode_or_tape(*args, **kwargs)
+        tape = qnode_or_tape._tape
+    elif isinstance(qnode_or_tape, qml.tape.QuantumTape):
+        tape = qnode_or_tape
+    else:
+        raise TypeError("Input must be a QNode or QuantumTape")
+    
+    # Translate to Jaqal
+    translator = HybridlaneToJaqalTranslator()
+    return translator.translate_circuit(tape)

--- a/test/export/test_hybridlane_ops_jaqal.py
+++ b/test/export/test_hybridlane_ops_jaqal.py
@@ -1,0 +1,122 @@
+"""Tests for Jaqal export with hybridlane-specific operations."""
+
+import pennylane as qml
+import pytest
+import hybridlane as hqml
+from hybridlane.export import to_jaqal
+
+
+class TestHybridlaneOpsJaqalExport:
+    """Test suite for exporting hybridlane-specific operations to Jaqal."""
+    
+    def test_cv_operations_placeholder(self):
+        """Test that CV operations generate appropriate placeholder comments."""
+        # Use a tape directly to avoid device restrictions
+        with qml.tape.QuantumTape() as tape:
+            # Mix of standard and CV operations
+            qml.RX(0.5, wires=0)
+            hqml.TwoModeSum(1.0, wires=[1, 2])  # CV operation
+            hqml.ModeSwap(wires=[2, 3])  # CV operation
+            hqml.Fourier(wires=1)  # CV operation
+            qml.expval(qml.PauliZ(0))
+        
+        jaqal_code = to_jaqal(tape)
+        
+        # Check for standard gate
+        assert "Rx 0.5 q[0]" in jaqal_code
+        # Check for CV operation placeholders
+        assert "// CV Operation: TwoModeSum" in jaqal_code
+        assert "// CV Operation: ModeSwap" in jaqal_code
+        assert "// CV Operation: Fourier" in jaqal_code
+        assert "Support coming soon" in jaqal_code
+    
+    def test_hybrid_operations_placeholder(self):
+        """Test that hybrid CV-DV operations generate appropriate placeholder comments."""
+        # Use a tape directly to avoid device restrictions
+        with qml.tape.QuantumTape() as tape:
+            # Mix of standard and hybrid operations
+            qml.Hadamard(wires=0)
+            hqml.ConditionalDisplacement(1.0, 0, wires=[1, 0])  # 2 wires: 1 mode, 1 qubit
+            hqml.JaynesCummings(0.5, 0.3, wires=[2, 1])  # 2 wires: 1 qubit, 1 mode; 2 params
+            qml.CNOT(wires=[0, 1])
+            qml.probs(wires=[0, 1])
+        
+        jaqal_code = to_jaqal(tape)
+        
+        # Check for standard gates (Hadamard decomposition)
+        assert "Ry" in jaqal_code
+        assert "Rz" in jaqal_code
+        # Check for CNOT decomposition
+        assert "MS" in jaqal_code
+        # Check for hybrid operation placeholders
+        assert "// Hybrid CV-DV Operation: ConditionalDisplacement" in jaqal_code
+        assert "// Hybrid CV-DV Operation: JaynesCummings" in jaqal_code
+        assert "Support coming soon" in jaqal_code
+    
+    def test_mixed_circuit(self):
+        """Test a circuit mixing standard, CV, and hybrid operations."""
+        # Use a tape directly to avoid device restrictions
+        with qml.tape.QuantumTape() as tape:
+            # Standard gates
+            qml.RY(0.3, wires=0)
+            qml.PauliX(wires=1)
+            
+            # CV operations
+            hqml.TwoModeSum(0.5, wires=[2, 3])
+            hqml.ModeSwap(wires=[2, 3])
+            hqml.Fourier(wires=2)
+            
+            # Hybrid operations
+            hqml.Rabi(1.5, wires=[0, 2])  # 2 wires: 1 qubit, 1 mode
+            hqml.ConditionalRotation(0.7, wires=[1, 2])  # 2 wires: 1 param (theta)
+            
+            # More standard gates
+            qml.CZ(wires=[0, 1])
+            
+            qml.state()
+        
+        jaqal_code = to_jaqal(tape)
+        
+        # Verify the circuit has all types of operations
+        assert "Ry 0.3 q[0]" in jaqal_code
+        assert "Rx 3.14159" in jaqal_code  # PauliX
+        assert "// CV Operation: TwoModeSum" in jaqal_code
+        assert "// CV Operation: ModeSwap" in jaqal_code
+        assert "// CV Operation: Fourier" in jaqal_code
+        assert "// Hybrid CV-DV Operation: Rabi" in jaqal_code
+        assert "// Hybrid CV-DV Operation: ConditionalRotation" in jaqal_code
+        assert "MS" in jaqal_code  # From CZ decomposition
+    
+    def test_selective_operations(self):
+        """Test selective qubit/number operations."""
+        # Use a tape directly to avoid device restrictions
+        with qml.tape.QuantumTape() as tape:
+            hqml.SelectiveQubitRotation(0.5, 0.2, 1, wires=[0, 1])  # theta, phi, n, wires
+            hqml.SelectiveNumberArbitraryPhase(1.0, 2, wires=[1, 2])  # phi, n, wires
+            hqml.AntiJaynesCummings(0.3, 0.2, wires=[0, 2])  # theta, phi, wires
+            qml.expval(qml.PauliZ(0))
+        
+        jaqal_code = to_jaqal(tape)
+        
+        assert "// Hybrid CV-DV Operation: SelectiveQubitRotation" in jaqal_code
+        assert "// Hybrid CV-DV Operation: SelectiveNumberArbitraryPhase" in jaqal_code
+        assert "// Hybrid CV-DV Operation: AntiJaynesCummings" in jaqal_code
+        assert "Support coming soon" in jaqal_code
+    
+    def test_conditional_operations(self):
+        """Test various conditional operations."""
+        # Use a tape directly to avoid device restrictions
+        with qml.tape.QuantumTape() as tape:
+            hqml.ConditionalBeamsplitter(0.5, 0.2, wires=[0, 1, 2])  # theta, phi, wires (3 wires: 1 qubit, 2 modes)
+            hqml.ConditionalTwoModeSqueezing(0.3, 0.1, wires=[0, 2, 3])  # r, phi, wires (3 wires)
+            hqml.ConditionalTwoModeSum(0.7, wires=[0, 1, 2])  # lambda, wires (3 wires)
+            hqml.ConditionalParity(wires=[0, 1])  # wires (2 wires)
+            qml.probs(wires=[0, 1, 2, 3])
+        
+        jaqal_code = to_jaqal(tape)
+        
+        assert "// Hybrid CV-DV Operation: ConditionalBeamsplitter" in jaqal_code
+        assert "// Hybrid CV-DV Operation: ConditionalTwoModeSqueezing" in jaqal_code
+        assert "// Hybrid CV-DV Operation: ConditionalTwoModeSum" in jaqal_code
+        assert "// Hybrid CV-DV Operation: ConditionalParity" in jaqal_code
+        assert "Support coming soon" in jaqal_code

--- a/test/export/test_jaqal.py
+++ b/test/export/test_jaqal.py
@@ -1,0 +1,112 @@
+"""Tests for Jaqal export functionality."""
+
+import pennylane as qml
+import pytest
+from hybridlane.export import to_jaqal
+
+
+class TestJaqalExport:
+    """Test suite for Jaqal export functionality."""
+    
+    def test_simple_circuit(self):
+        """Test export of a simple single-qubit circuit."""
+        dev = qml.device("default.qubit", wires=1)
+        
+        @qml.qnode(dev)
+        def circuit():
+            qml.RX(0.5, wires=0)
+            qml.RY(1.0, wires=0)
+            return qml.expval(qml.PauliZ(0))
+        
+        jaqal_code = to_jaqal(circuit)
+        
+        assert "register q[1]" in jaqal_code
+        assert "prepare_all" in jaqal_code
+        assert "Rx 0.5 q[0]" in jaqal_code
+        assert "Ry 1.0 q[0]" in jaqal_code
+        assert "measure_all" in jaqal_code
+    
+    def test_two_qubit_circuit(self):
+        """Test export of a two-qubit circuit with entanglement."""
+        dev = qml.device("default.qubit", wires=2)
+        
+        @qml.qnode(dev)
+        def circuit():
+            qml.Hadamard(wires=0)
+            qml.CNOT(wires=[0, 1])
+            return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
+        
+        jaqal_code = to_jaqal(circuit)
+        
+        assert "register q[2]" in jaqal_code
+        assert "prepare_all" in jaqal_code
+        # Hadamard decomposition
+        assert "Ry" in jaqal_code
+        assert "Rz" in jaqal_code
+        # CNOT decomposition using MS gates
+        assert "MS" in jaqal_code
+        assert "measure_all" in jaqal_code
+    
+    def test_pauli_gates(self):
+        """Test conversion of Pauli gates."""
+        dev = qml.device("default.qubit", wires=1)
+        
+        @qml.qnode(dev)
+        def circuit():
+            qml.PauliX(wires=0)
+            qml.PauliY(wires=0)
+            qml.PauliZ(wires=0)
+            return qml.expval(qml.PauliZ(0))
+        
+        jaqal_code = to_jaqal(circuit)
+        
+        # Pauli gates should be converted to rotations by pi
+        assert "Rx 3.14159" in jaqal_code
+        assert "Ry 3.14159" in jaqal_code
+        assert "Rz 3.14159" in jaqal_code
+    
+    def test_multi_qubit_circuit(self):
+        """Test export of a multi-qubit circuit."""
+        dev = qml.device("default.qubit", wires=3)
+        
+        @qml.qnode(dev)
+        def circuit():
+            qml.RX(0.1, wires=0)
+            qml.RY(0.2, wires=1)
+            qml.RZ(0.3, wires=2)
+            qml.CNOT(wires=[0, 1])
+            qml.CZ(wires=[1, 2])
+            return qml.probs(wires=[0, 1, 2])
+        
+        jaqal_code = to_jaqal(circuit)
+        
+        assert "register q[3]" in jaqal_code
+        assert "Rx 0.1 q[0]" in jaqal_code
+        assert "Ry 0.2 q[1]" in jaqal_code
+        assert "Rz 0.3 q[2]" in jaqal_code
+    
+    def test_tape_export(self):
+        """Test direct export from a QuantumTape."""
+        with qml.tape.QuantumTape() as tape:
+            qml.RX(1.5, wires=0)
+            qml.RY(2.0, wires=1)
+            qml.CNOT(wires=[0, 1])
+            qml.expval(qml.PauliZ(0))
+        
+        jaqal_code = to_jaqal(tape)
+        
+        assert "register q[2]" in jaqal_code
+        assert "Rx 1.5 q[0]" in jaqal_code
+        assert "Ry 2.0 q[1]" in jaqal_code
+    
+    def test_unsupported_gate_error(self):
+        """Test that unsupported gates raise appropriate errors."""
+        dev = qml.device("default.qubit", wires=3)
+        
+        @qml.qnode(dev)
+        def circuit():
+            qml.Toffoli(wires=[0, 1, 2])
+            return qml.expval(qml.PauliZ(0))
+        
+        with pytest.raises(NotImplementedError, match="not yet supported"):
+            to_jaqal(circuit)


### PR DESCRIPTION
- Implement HybridlaneToJaqalTranslator with gate mappings
- Support standard gates (Pauli, rotations, Hadamard, CNOT, CZ)
- Add placeholder system for CV and hybrid CV-DV operations
- Include gate decompositions for trapped-ion architecture
- Add comprehensive test suite (11 tests)
- Provide example scripts and documentation

This enables translation of hybridlane/PennyLane circuits to Jaqal assembly language for execution on trapped-ion quantum computers.