### PR TITLE
Implement Sandia ion trap

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pip install hybridlane[extras]
 
 **Available Extra Flags:**
 *   `[all]`: Installs all extra flags.
-*   `[bq]`: Installs support for the `hybrid.bosonicqiskit` simulation device.
+*   `[bq]`: Installs support for the `bosonicqiskit.hybrid` simulation device.
 
 For more detailed installation instructions and environment setup, please refer to the [Getting Started Guide in our Documentation](https://pnnl.github.io/hybridlane/getting-started.html).
 
@@ -69,7 +69,7 @@ import pennylane as qml
 import hybridlane as hqml
 
 # Create the bosonic qiskit simulator with custom Fock truncation
-dev = qml.device("hybrid.bosonicqiskit", max_fock_level=8)
+dev = qml.device("bosonicqiskit.hybrid", max_fock_level=8)
 
 # Define a hybrid circuit with familiar Pennylane syntax
 @qml.qnode(dev)
@@ -112,7 +112,7 @@ While hybridlane provides a powerful framework for hybrid quantum circuits, it's
     Currently, hybridlane does not support PennyLane's Catalyst and `qjit` capabilities. This would require developing a custom MLIR dialect for hybrid operations, which is a significant undertaking. While not on the immediate roadmap, this could be a potential feature in the future.
 
 *   **❌ Automatic Differentiation (Autodiff):**
-    While our gate definitions are fundamentally compatible with PennyLane's differentiability paradigm, we do not yet provide a differentiable simulator device, nor are gradient recipes fully defined for all hybrid operations. For now, the `hybrid.bosonicqiskit` device will typically require finite differences for gradient computation. We plan to integrate more robust autodiff capabilities in future releases.
+    While our gate definitions are fundamentally compatible with PennyLane's differentiability paradigm, we do not yet provide a differentiable simulator device, nor are gradient recipes fully defined for all hybrid operations. For now, the `bosonicqiskit.hybrid` device will typically require finite differences for gradient computation. We plan to integrate more robust autodiff capabilities in future releases.
 
 ---
 

--- a/docs/source/exporting-circuits.rst
+++ b/docs/source/exporting-circuits.rst
@@ -12,7 +12,7 @@ Here we give an example of exporting a basic circuit to OpenQASM. Consider the f
 
 .. code:: python
 
-    dev = qml.device("hybrid.bosonicqiskit")
+    dev = qml.device("bosonicqiskit.hybrid")
 
     @qml.qnode(dev)
     def circuit(n):

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -10,7 +10,7 @@ This package can be installed from PyPI with
 The available extra flags are:
 
 - ``all``: Installs all extra flags.
-- ``bq``: Adds support for the ``hybrid.bosonicqiskit`` device.
+- ``bq``: Adds support for the ``bosonicqiskit.hybrid`` device.
 
 Developing
 ----------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -53,7 +53,7 @@ The package can be installed from PyPI with
 **Available Extra Flags:**
 
 *   ``[all]``: Installs all extra flags.
-*   ``[bq]``: Installs support for the ``hybrid.bosonicqiskit`` simulation device.
+*   ``[bq]``: Installs support for the ``bosonicqiskit.hybrid`` simulation device.
 
 For more detailed installation instructions and environment setup, please refer to the :doc:`Getting Started Guide in our Documentation <getting-started>`.
 
@@ -71,7 +71,7 @@ Get started with hybridlane in just a few lines of code:
     import hybridlane as hqml
 
     # Create the bosonic qiskit simulator with custom Fock truncation
-    dev = qml.device("hybrid.bosonicqiskit", max_fock_level=8)
+    dev = qml.device("bosonicqiskit.hybrid", max_fock_level=8)
 
     # Define a hybrid circuit with familiar Pennylane syntax
     @qml.qnode(dev)
@@ -114,7 +114,7 @@ While hybridlane provides a powerful framework for hybrid quantum circuits, it's
     Currently, hybridlane does not support PennyLane's Catalyst and ``qjit`` capabilities. This would require developing a custom MLIR dialect for hybrid operations, which is a significant undertaking. While not on the immediate roadmap, this could be a potential feature in the future.
 
 *   **❌ Automatic Differentiation (Autodiff):**
-    While our gate definitions are fundamentally compatible with PennyLane's differentiability paradigm, we do not yet provide a differentiable simulator device, nor are gradient recipes fully defined for all hybrid operations. For now, the ``hybrid.bosonicqiskit`` device will typically require finite differences for gradient computation. We plan to integrate more robust autodiff capabilities in future releases.
+    While our gate definitions are fundamentally compatible with PennyLane's differentiability paradigm, we do not yet provide a differentiable simulator device, nor are gradient recipes fully defined for all hybrid operations. For now, the ``bosonicqiskit.hybrid`` device will typically require finite differences for gradient computation. We plan to integrate more robust autodiff capabilities in future releases.
 
 
 

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -60,7 +60,7 @@ This code imports both Pennylane (``qml``) to get access to its decorators and t
 
     dev = qml.device('hybrid.device')
 
-When simulating circuits in Pennylane, circuits are usually bound to devices. You must choose a device that supports the operations in your circuit, or you'll obtain an error (for example, using ``qml.Displacement`` gates with the ``default.qubit`` device). This line initializes the device registered with name ``hybrid.device``. Note that while we picked a fictional device for the purposes of providing a clean example, Hybridlane does provide a reference simulator device based on Bosonic Qiskit, ``hybrid.bosonicqiskit``.
+When simulating circuits in Pennylane, circuits are usually bound to devices. You must choose a device that supports the operations in your circuit, or you'll obtain an error (for example, using ``qml.Displacement`` gates with the ``default.qubit`` device). This line initializes the device registered with name ``hybrid.device``. Note that while we picked a fictional device for the purposes of providing a clean example, Hybridlane does provide a reference simulator device based on Bosonic Qiskit, ``bosonicqiskit.hybrid``.
 
 .. code:: python
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,8 @@ all = [
 ]
 
 [project.entry-points."pennylane.plugins"]
-"hybrid.bosonicqiskit" = "hybridlane.devices:BosonicQiskitDevice"
+"bosonicqiskit.hybrid" = "hybridlane.devices:BosonicQiskitDevice"
+"sandiaqscout.hybrid" = "hybridlane.devices:QscoutIonTrap"
 
 [build-system]
 requires = ["uv_build>=0.8.13,<0.9.0"]

--- a/src/hybridlane/__init__.py
+++ b/src/hybridlane/__init__.py
@@ -3,9 +3,10 @@
 # This software is licensed under the 2-Clause BSD License.
 # See the LICENSE.txt file for full license text.
 
-from . import sa, transforms
-from .drawer import draw_mpl
-from .io import to_openqasm
-from .measurements import expval, sample, var
-from .ops import *
-from .transforms import from_pennylane
+from hybridlane import sa, transforms
+from hybridlane.drawer import draw_mpl
+from hybridlane.io import to_openqasm
+from hybridlane.measurements import expval, sample, var
+from hybridlane.ops import *
+from hybridlane.templates import FockLadder
+from hybridlane.transforms import from_pennylane

--- a/src/hybridlane/devices/__init__.py
+++ b/src/hybridlane/devices/__init__.py
@@ -4,5 +4,6 @@
 # See the LICENSE.txt file for full license text.
 from . import preprocess
 from .bosonic_qiskit import BosonicQiskitDevice
+from .sandia_qscout import QscoutIonTrap
 
-__all__ = ["preprocess", "BosonicQiskitDevice"]
+__all__ = ["preprocess", "BosonicQiskitDevice", "QscoutIonTrap"]

--- a/src/hybridlane/devices/bosonic_qiskit/device.py
+++ b/src/hybridlane/devices/bosonic_qiskit/device.py
@@ -116,8 +116,10 @@ def is_sampled_observable_supported(o: Operator) -> bool:
 class BosonicQiskitDevice(Device):
     r"""Backend for Pennylane that executes hybrid CV-DV circuits in Bosonic Qiskit"""
 
-    name = "hybrid.bosonicqiskit"  # type: ignore
-    short_name = "bosonic-qiskit"
+    name = "Bosonic Qiskit"  # type: ignore
+    shortname = "bosonic-qiskit"
+    version = "0.1.0"
+    author = "PNNL"
 
     _device_options = ("truncation", "hbar")
 
@@ -148,7 +150,7 @@ class BosonicQiskitDevice(Device):
 
         if importlib.util.find_spec("c2qa") is None:
             raise ImportError(
-                f"The {self.short_name} device depends on bosonic-qiskit, "
+                f"The {self.name} device depends on bosonic-qiskit, "
                 "which can be installed with `pip install hybrid-circuit[bq]`"
             )
 

--- a/src/hybridlane/devices/sandia_qscout/__init__.py
+++ b/src/hybridlane/devices/sandia_qscout/__init__.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2025, Battelle Memorial Institute
+
+# This software is licensed under the 2-Clause BSD License.
+# See the LICENSE.txt file for full license text.
+from . import ops
+from .device import QscoutIonTrap
+from .draw import get_default_style
+from .jaqal import tape_to_jaqal, to_jaqal
+
+__all__ = ["ops", "QscoutIonTrap", "get_default_style", "tape_to_jaqal", "to_jaqal"]

--- a/src/hybridlane/devices/sandia_qscout/device.py
+++ b/src/hybridlane/devices/sandia_qscout/device.py
@@ -1,0 +1,474 @@
+# Copyright (c) 2025, Battelle Memorial Institute
+
+# This software is licensed under the 2-Clause BSD License.
+# See the LICENSE.txt file for full license text.
+
+r"""Device definition for Sandia Qscout ion trap"""
+
+import math
+import re
+from dataclasses import replace
+from functools import singledispatch
+from typing import Hashable, Optional, Sequence, cast
+
+import numpy as np
+import pennylane as qml
+from pennylane.decomposition import (
+    add_decomps,
+    register_resources,
+)
+from pennylane.devices import DefaultExecutionConfig, Device
+from pennylane.devices.execution_config import ExecutionConfig
+from pennylane.devices.modifiers import single_tape_support
+from pennylane.devices.preprocess import (
+    validate_device_wires,
+    validate_measurements,
+)
+from pennylane.exceptions import DeviceError
+from pennylane.measurements import MeasurementProcess
+from pennylane.operation import Operator
+from pennylane.ops.functions.simplify import _simplify_transform
+from pennylane.pauli import PauliSentence
+from pennylane.tape import QuantumScript
+from pennylane.transforms import (
+    cancel_inverses,
+    combine_global_phases,
+    commute_controlled,
+    decompose,
+    diagonalize_measurements,
+    merge_rotations,
+    single_qubit_fusion,
+)
+from pennylane.transforms.core import TransformProgram
+from pennylane.wires import Wires
+
+import hybridlane as hqml
+
+from ... import sa
+from ...measurements import SampleMeasurement
+from ...transforms import from_pennylane
+from ..preprocess import static_analyze_tape
+from . import jaqal, ops
+from .ops import (
+    ConditionalXDisplacement,
+)
+
+# --------------------------------------------
+#     Rules about what the device handles
+# --------------------------------------------
+
+
+def accepted_sample_measurement(m: MeasurementProcess) -> bool:
+    if not isinstance(m, SampleMeasurement):
+        return False
+
+    if m.obs is not None:
+        return is_sampled_observable_supported(m.obs)
+
+    return True
+
+
+def is_sampled_observable_supported(o: Operator) -> bool:
+    if o.pauli_rep:
+        pr = cast(PauliSentence, o.pauli_rep)
+        return len(pr) == 1
+
+    return False
+
+
+NATIVE_GATES = set(jaqal.QUBIT_GATES) | set(jaqal.BOSON_GATES)
+
+
+# Define constraints on the gates
+@singledispatch
+def is_gate_supported(_: Operator):
+    return True
+
+
+@is_gate_supported.register
+def _(op: ops.FockStatePrep):
+    # Hardcoded to the tilt modes
+    return op.wires[1] in ("a0m1", "a1m1")
+
+
+@is_gate_supported.register
+def _(op: ops.ConditionalXDisplacement):
+    # Hardcoded to the tilt mode on axis 0
+    return op.wires[1] == "a0m1"
+
+
+@is_gate_supported.register
+def _(op: ops.ConditionalXSqueezing):
+    # Hardcoded to the tilt mode on axis 0
+    return op.wires[1] == "a0m1"
+
+
+@is_gate_supported.register
+def _(op: ops.NativeBeamsplitter):
+    # Only supported between the tilt modes
+    return op.wires.contains_wires(Wires(["a0m1", "a1m1"]))
+
+
+@single_tape_support
+class QscoutIonTrap(Device):
+    r"""Backend for Pennylane that prepares circuits to be run on the Sandia QSCOUT ion trap
+
+    This device can't actually execute anything; instead, it's intended as a compilation target.
+    As an example of how to compile a circuit to this device,
+
+    .. code:: python
+
+        import pennylane as qml
+        import hybridlane as hqml
+        from hybridlane.devices.sandia_qscout import QscoutIonTrap
+        from pennylane.workflow import construct_tape
+
+        dev = QscoutIonTrap(shots=1000)
+
+        @qml.qnode(dev)
+        def circuit():
+            hqml.FockLadder(5, [0, "a0m1"])
+            return hqml.expval(qml.Z(0))
+
+        tape = construct_tape(circuit)()
+
+    """
+
+    name = "Sandia Qscout Ion Trap"  # type: ignore
+    shortname = "qscout"
+    version = "0.1.0"
+    pennylane_requires = ">=0.42.0"
+    author = "PNNL"
+
+    _max_qubits = 6
+    _device_options = (
+        "n_qubits",
+        "optimize",
+        "use_com_modes",
+        "use_hardware_wires",
+        "use_fockstate_instruction",
+    )
+
+    def __init__(
+        self,
+        wires: Optional[int | Sequence[Hashable]] = None,
+        shots: Optional[int] = None,
+        n_qubits: Optional[int] = None,
+        optimize: bool = True,
+        use_com_modes: bool = False,
+        use_hardware_wires: bool = False,
+        use_fockstate_instruction: bool = True,
+    ):
+        r"""Initializes the device
+
+        Args:
+            wires: An optional list of wires to expect in each circuit. If this is passed, then executing
+                a circuit will error if it has any wire not in `wires`
+
+            shots: The number of shots to use for a measurement
+
+            n_qubits: The number of qubits per circuit. If None (default), this will be inferred from
+                each circuit. By setting this number to more qubits than are used in the circuit,
+                this can grant access to additional qumodes.
+
+            optimize: Whether to perform any simplifications of the circuit including cancelling inverse
+                gates, merging consecutive rotations, and commuting controlled operators
+
+            use_com_modes: If True, the center-of-mass qumodes are enabled. As they are likely
+                to be very noisy due to heating, they are disabled by default.
+
+            use_hardware_wires: If True, the circuit must contain only physical qumode/qubit wires.
+                If False (default), the device will assign available physical qubits and qumodes to
+                algorithmic (virtual) wires.
+
+            use_fockstate_instruction: If True (default), all :class:`~hybridlane.FockLadder` gates
+                acting on the tilt modes will be replaced by the native instruction instead of
+                being decomposed into blue/red gates.
+        """
+
+        if use_hardware_wires:
+            qubits = n_qubits or self._max_qubits
+            wires = _get_allowed_device_wires(qubits, use_com_modes)
+
+        super().__init__(wires=wires, shots=shots)
+
+        self._n_qubits = n_qubits
+        self._optimize = optimize
+        self._use_com_modes = use_com_modes
+        self._use_hardware_wires = use_hardware_wires
+        self._use_fockstate_instruction = use_fockstate_instruction
+
+    def execute(  # type: ignore
+        self,
+        circuits: Sequence[QuantumScript],
+        execution_config: ExecutionConfig = DefaultExecutionConfig,
+    ):
+        # We can't actually execute anything, instead this device is just meant
+        # as a compilation target.
+        return (0,) * len(circuits)
+
+    def setup_execution_config(
+        self,
+        config: ExecutionConfig | None = None,
+        circuit: QuantumScript | None = None,
+    ) -> ExecutionConfig:
+        config = config or ExecutionConfig()
+        updated_values = {}
+
+        for option in config.device_options or {}:
+            if option not in self._device_options:
+                raise DeviceError(f"Device option {option} not present on {self}")
+
+        updated_values["device_options"] = dict(config.device_options)  # copy
+
+        if circuit and updated_values["device_options"].get("n_qubits") is None:
+            sa_res = sa.analyze(circuit)
+            updated_values["device_options"]["n_qubits"] = len(sa_res.qubits)
+
+        for option in self._device_options:
+            if option not in updated_values["device_options"]:
+                updated_values["device_options"][option] = getattr(self, f"_{option}")
+
+        return replace(config, **updated_values)
+
+    def preprocess_transforms(
+        self, execution_config: ExecutionConfig | None = None
+    ) -> TransformProgram:
+        execution_config = execution_config or ExecutionConfig()
+        device_options = execution_config.device_options or {}
+
+        transform_program = TransformProgram()
+
+        # Convert pennylane gates to hybridlane
+        transform_program.add_transform(from_pennylane)
+
+        # If virtual wires are allowed, we need to assign them
+        max_qubits = device_options.get("n_qubits", self._n_qubits) or self._max_qubits
+        use_com_modes = device_options.get("use_com_modes", self._use_com_modes)
+        if not device_options.get("use_hardware_wires", self._use_hardware_wires):
+            transform_program.add_transform(
+                assign_initial_layout,
+                max_qubits=max_qubits,
+                use_com_modes=use_com_modes,
+            )
+
+        # Validate all wires are assigned to proper physical addresses
+        allowed_wires = _get_allowed_device_wires(max_qubits, use_com_modes)
+        transform_program.add_transform(
+            validate_device_wires, wires=allowed_wires, name=self.name
+        )
+
+        # Qubit/qumode type checking
+        transform_program.add_transform(static_analyze_tape)
+
+        # Measurement check
+        transform_program.add_transform(
+            validate_measurements,
+            analytic_measurements=lambda *_: False,
+            sample_measurements=accepted_sample_measurement,
+            name=self.name,
+        )
+
+        # Expand any unsupported fockstate operations because decompose transform
+        # below won't (it's a native gate)
+        transform_program.add_transform(
+            expand_unsupported_fockstate,
+            use_native_instruction=device_options.get(
+                "use_fockstate_instruction", self._use_fockstate_instruction
+            ),
+        )
+
+        # Make everything measurable in pauli z basis. Diagonalize prior to
+        # decompose so that it decomposes unsupported gates
+        transform_program.add_transform(diagonalize_measurements)
+
+        # Decompose all gates into the native gate set
+        transform_program.add_transform(decompose, gate_set=NATIVE_GATES)
+
+        # Optional optimizations
+        if device_options.get("optimize", self._optimize):
+            transform_program.add_transform(commute_controlled)
+            transform_program.add_transform(cancel_inverses)
+            transform_program.add_transform(merge_rotations)
+
+            # Fuse single qubit gates into Rot, then hopefully decompose them into
+            # R gates
+            transform_program.add_transform(single_qubit_fusion)
+            transform_program.add_transform(decompose, gate_set=NATIVE_GATES)
+
+            # Simplify any rotation parameters, then decompose again will delete
+            # Identity from the circuit
+            transform_program.add_transform(_simplify_transform)
+            transform_program.add_transform(decompose, gate_set=NATIVE_GATES)
+
+            transform_program.add_transform(combine_global_phases)
+
+        # Finally check all native gates. This takes into account additional constraints
+        # like gates being defined only on certain qumodes that decompose doesn't know about
+        transform_program.add_transform(validate_gates_supported_on_hardware)
+
+        return transform_program
+
+
+@qml.transform
+def validate_gates_supported_on_hardware(tape: QuantumScript):
+    for op in tape.operations:
+        if not is_gate_supported(op):
+            raise DeviceError(f"Operation {op} is not supported natively")
+
+    def null_postprocessing(results):
+        return results[0]
+
+    return (tape,), null_postprocessing
+
+
+@qml.transform
+def assign_initial_layout(
+    tape: QuantumScript,
+    sa_res: Optional[sa.StaticAnalysisResult] = None,
+    max_qubits: Optional[int] = None,
+    use_com_modes: bool = False,
+):
+    if sa_res is None:
+        sa_res = sa.analyze(tape)
+
+    max_qubits = max_qubits or len(sa_res.qubits)
+    max_qumodes = 2 * max_qubits if use_com_modes else 2 * max_qubits - 2
+    qubits, qumodes = sa_res.qubits, sa_res.qumodes
+
+    if len(qubits) > max_qubits:
+        raise DeviceError(
+            f"Circuit has more qubits ({len(qubits)}) than the maximum "
+            f"requested or allowed ({max_qubits})"
+        )
+
+    if len(qumodes) > max_qumodes:
+        raise DeviceError(
+            f"Circuit has more qumodes ({len(qumodes)}) than the maximum "
+            f"requested or allowed ({max_qumodes})"
+        )
+
+    wire_map = {}
+    occupied_qumodes = {axis: set() for axis in (0, 1)}
+
+    # If any qumodes match the convention m<mode>a<axis>, keep them, enabling users to
+    # be specific about what mode they want to target
+    unmapped_qumodes = []
+    qumode_pattern = re.compile(r"^a([01])m(\d+)$")
+    for wire in qumodes:
+        if isinstance(wire, str) and (match := qumode_pattern.match(wire)):
+            axis = int(match.group(1))
+            i = int(match.group(2))
+            occupied_qumodes[axis].add(i)
+            wire_map[wire] = wire
+        else:
+            unmapped_qumodes.append(wire)
+
+    # Generic algorithmic qumodes will get mapped to the lowest available index
+    min_qumode_idx = 1 - use_com_modes
+    i = min_qumode_idx
+    axis = 0
+
+    def transition():
+        return (i + axis, (axis + 1) % 2)
+
+    for wire in sorted(unmapped_qumodes):
+        found = False
+        while not found:
+            if i not in occupied_qumodes[axis]:
+                found = True
+                occupied_qumodes[axis].add(i)
+                wire_map[wire] = f"a{axis}m{i}"
+
+            i, axis = transition()
+
+    # Just assign qubits indices 0..n
+    for i, wire in enumerate(sorted(qubits)):
+        wire_map[wire] = i
+
+    def null_postprocessing(results):
+        return results[0]
+
+    tape_batch, _ = qml.map_wires(tape, wire_map)
+    return tape_batch, null_postprocessing
+
+
+@qml.transform
+def expand_unsupported_fockstate(
+    tape: QuantumScript, use_native_instruction: bool = True
+):
+    new_ops = []
+
+    for op in tape.operations:
+        if isinstance(op, ops.FockStatePrep):
+            if use_native_instruction and is_gate_supported(op):
+                new_ops.append(op)
+
+            else:
+                new_ops.extend(op.decomposition())
+
+        else:
+            new_ops.append(op)
+
+    def null_postprocessing(results):
+        return results[0]
+
+    new_tape = QuantumScript(new_ops, tape.measurements, tape.shots)
+    return (new_tape,), null_postprocessing
+
+
+# Define gate decompositions. Note that many gates have already been defined
+# in pennylane in terms of R{x,y,z} gates, which are native.
+
+
+@register_resources({qml.IsingXX: 1, qml.RY: 2, qml.RX: 2})
+def _cnot_decomp(wires, **_):
+    # Taken from https://en.wikipedia.org/wiki/Mølmer–Sørensen_gate#Description
+    qml.RY(math.pi / 2, wires[0])
+    qml.IsingXX(math.pi / 2, wires)
+    qml.RX(-math.pi / 2, wires[1])
+    qml.RX(-math.pi / 2, wires[0])
+    qml.RY(-math.pi / 2, wires[0])
+
+
+add_decomps(qml.CNOT, _cnot_decomp)
+
+
+@register_resources({qml.GlobalPhase: 1, ops.R: 2})
+def _rot_decomp(phi, theta, omega, wires, **_):
+    ops.R(theta - math.pi, math.pi / 2 - phi, wires=wires)
+    ops.R(math.pi, (omega - phi) / 2 + math.pi / 2, wires=wires)
+    qml.GlobalPhase((phi + omega) / 2)
+
+
+add_decomps(qml.Rot, _rot_decomp)
+
+
+@register_resources({ConditionalXDisplacement: 1, qml.H: 2})
+def _conditionaldisplacement_decomp(*params, wires, **_):
+    r, phi = params
+    beta = r * np.exp(1j * phi)
+
+    qml.H(wires[0])
+    ConditionalXDisplacement(np.real(beta), np.imag(beta), wires=wires)
+    qml.H(wires[0])
+
+
+add_decomps(hqml.ConditionalDisplacement, _conditionaldisplacement_decomp)
+
+# Currently unknown how to decompose normal squeezing parameters to red/blue sideband ratios
+# @register_resources({ConditionalXSqueezing: 1, qml.H: 2})
+# def _conditionalsqueezing_decomp(*params, wires, **_):
+#     qml.H(wires[0])
+#     ConditionalXSqueezing(*params, wires=wires)
+#     qml.H(wires[0])
+
+
+# add_decomps(hqml.ConditionalSqueezing, _conditionalsqueezing_decomp)
+
+
+def _get_allowed_device_wires(max_qubits: int, use_com_modes: bool):
+    min_qumode_idx = 1 - use_com_modes
+    qubits = list(range(max_qubits))
+    qumodes = [f"a{a}m{i}" for i in range(min_qumode_idx, max_qubits) for a in (0, 1)]
+    return qubits + qumodes

--- a/src/hybridlane/devices/sandia_qscout/draw.py
+++ b/src/hybridlane/devices/sandia_qscout/draw.py
@@ -1,0 +1,35 @@
+r"""Contains drawing utilities for quantum circuits on the ion trap"""
+
+from .device import _get_allowed_device_wires, QscoutIonTrap
+
+_mode_colors = {
+    0: "tomato",
+    1: "orange",
+    2: "gold",
+    3: "lime",
+    4: "turquoise",
+    5: "violet",
+}
+
+
+def get_default_style():
+    r"""Gives some defaults for drawing circuits using ``hqml.draw_mpl``
+
+    This adds the following styles to a quantum circuit:
+
+    * Qubits are listed before qumodes, and qumodes are plotted from low to high (in terms of mode)
+    * Qumodes are colored by their mode to be rainbow
+
+    This only works if drawing a circuit at the device level, after the circuit wires
+    have been mapped to the hardware wires of the ``QscoutIonTrap`` device.
+    """
+    wire_order = _get_allowed_device_wires(QscoutIonTrap._max_qubits, True)
+
+    # Color the qumodes rainbow like the slides
+    icon_colors = {}
+    for wire in wire_order:
+        if isinstance(wire, str):
+            mode = int(wire[-1])
+            icon_colors[wire] = _mode_colors[mode]
+
+    return {"wire_icon_colors": icon_colors, "wire_order": wire_order}

--- a/src/hybridlane/devices/sandia_qscout/jaqal.py
+++ b/src/hybridlane/devices/sandia_qscout/jaqal.py
@@ -1,0 +1,216 @@
+# Copyright (c) 2025, Battelle Memorial Institute
+
+# This software is licensed under the 2-Clause BSD License.
+# See the LICENSE.txt file for full license text.
+
+r"""Module for exporting circuits compiled to the ion trap to the Jaqal format"""
+
+import re
+from functools import singledispatch, wraps
+from typing import Optional, Union
+
+import pennylane as qml
+from pennylane.exceptions import DeviceError
+from pennylane.operation import Operation
+from pennylane.tape import QuantumScript
+
+import hybridlane as hqml
+
+from ... import sa
+from . import ops as native_ops
+
+# Mappings from the names of gates to Jaqal
+# Obtainable from https://gitlab.com/jaqal/qscout-gatemodels/-/blob/master/src/qscout/v1/std/jaqal_gates.py?ref_type=heads
+QUBIT_GATES = {
+    "GlobalPhase": None,
+    # "I": None,
+    "R": "R",
+    "RX": "Rx",
+    "RY": "Ry",
+    "RZ": "Rz",
+    "PauliX": "Px",
+    "PauliY": "Py",
+    "PauliZ": "Pz",
+    "SX": "Sx",
+    "Adjoint(SX)": "Sxd",
+    # No Sy in pennylane
+    "S": "Sz",
+    "Adjoint(S)": "Szd",
+    "IsingXX": "XX",  # MS = Rxx(π/2)
+    "IsingYY": "YY",
+    "IsingZZ": "ZZ",
+}
+
+# Taken from the slides
+BOSON_GATES = {
+    "JaynesCummings": "Red",
+    "AntiJaynesCummings": "Blue",
+    "FockLadder": "FockState",
+    "ConditionalXDisplacement": "SDF",
+    "ConditionalXSqueezing": "RampUp",
+    "NativeBeamsplitter": "Beamsplitter",
+    "SidebandProbe": "Rt_SBProbe",
+}
+
+
+def to_jaqal(
+    qnode, level: Optional[str | int | slice] = None, precision: Optional[float] = None
+):
+    from pennylane.workflow import construct_tape
+
+    @wraps(qnode)
+    def wrapper(*args, **kwargs) -> str:
+        tape = construct_tape(qnode, level=level)(*args, **kwargs)
+        return tape_to_jaqal(
+            tape,
+            precision=precision,
+        )
+
+    return wrapper
+
+
+def tape_to_jaqal(tape: QuantumScript, precision: Optional[float] = None):
+    sa_res = sa.analyze(tape)
+    num_qubits = len(sa_res.qubits)
+
+    program = f"register q[{num_qubits}]\n\n"
+    program += "prepare_all\n"
+    for op in tape.operations:
+        program += tokenize_operation(op, precision=precision) + "\n"
+
+    program += "measure_all"
+    return program
+
+
+@singledispatch
+def tokenize_operation(op: Operation, precision: Optional[float] = None) -> str:
+    if gate_id := QUBIT_GATES.get(op.name, None):
+        params = _tokenize_params(op.parameters, precision=precision)
+        wires = [f"q[{w}]" for w in op.wires]
+        return " ".join(map(str, [gate_id, *wires, *params]))
+
+    raise DeviceError(f"Unregistered operation: {op}")
+
+
+@tokenize_operation.register
+def _(op: native_ops.R, precision: Optional[int] = None):
+    gate_id = QUBIT_GATES[op.name]
+    angle, axis_angle = _tokenize_params(op.parameters, precision=precision)
+    qubit = op.wires[0]
+
+    return f"{gate_id} q[{qubit}] {axis_angle} {angle}"
+
+
+@tokenize_operation.register
+def _(_op: Union[qml.GlobalPhase, qml.Identity], **_):
+    return ""
+
+
+@tokenize_operation.register
+def _(op: hqml.JaynesCummings, precision: Optional[float] = None):
+    # Has format Red <qubit> <Fock state> <phase> <angle> <axis choice> <mode choice>
+    gate_id = BOSON_GATES[op.name]
+    params = _tokenize_params(op.parameters, precision=precision)
+    qubit, mode = op.wires
+    axis, mode_idx = _get_axis_and_index(mode)
+
+    # Hard code - the user has to compensate for the calibration at the moment
+    fock_state = 1
+
+    return (
+        f"{gate_id} q[{qubit}] {fock_state} {params[1]} {params[0]} {axis} {mode_idx}"
+    )
+
+
+@tokenize_operation.register
+def _(op: hqml.AntiJaynesCummings, precision: Optional[float] = None):
+    # Has format Blue <qubit> <Fock state> <phase> <angle> <axis choice> <mode choice>
+    gate_id = BOSON_GATES[op.name]
+    params = _tokenize_params(op.parameters, precision=precision)
+    qubit, mode = op.wires
+    axis, mode_idx = _get_axis_and_index(mode)
+
+    # Hard code - the user has to compensate for the calibration at the moment
+    fock_state = 1
+
+    return (
+        f"{gate_id} q[{qubit}] {fock_state} {params[1]} {params[0]} {axis} {mode_idx}"
+    )
+
+
+@tokenize_operation.register
+def _(op: native_ops.FockStatePrep, **_):
+    # Has format FockState <qubit> <fock state> <axis>
+    gate_id = BOSON_GATES[op.name]
+    fock_state = int(op.parameters[0])
+    qubit, mode = op.wires
+    axis, mode_idx = _get_axis_and_index(mode)
+
+    return f"{gate_id} q[{qubit}] {fock_state} {axis}"
+
+
+@tokenize_operation.register
+def _(op: native_ops.SidebandProbe, precision: Optional[float] = None):
+    # Has format Rt_SBProbe <qubit> <phase> <duration_us> <axis> <mode> <sign> <detuning>
+    gate_id = BOSON_GATES[op.name]
+    [duration_us, phase, detuning] = _tokenize_params(
+        [op.parameters[i] for i in (0, 1, 3)], precision=precision
+    )
+    sign = f"{op.parameters[2]:d}"
+    qubit, mode = op.wires
+    axis, mode_idx = _get_axis_and_index(mode)
+
+    return f"{gate_id} q[{qubit}] {phase} {duration_us} {axis} {mode_idx} {sign} {detuning}"
+
+
+@tokenize_operation.register
+def _(op: native_ops.ConditionalXDisplacement, precision: Optional[float] = None):
+    # Has format SDF <qubit> <beta_re> <beta_im>
+    gate_id = BOSON_GATES[op.name]
+    params = _tokenize_params(op.parameters, precision=precision)
+    qubit, mode = op.wires
+    axis, mode_idx = _get_axis_and_index(mode)
+
+    return f"{gate_id} q[{qubit}] {params[0]} {params[1]}"
+
+
+@tokenize_operation.register
+def _(op: native_ops.ConditionalXSqueezing, precision: Optional[float] = None):
+    # Has format RampUp <qubit> <blue/red ratio>
+    gate_id = BOSON_GATES[op.name]
+    params = _tokenize_params(op.parameters, precision=precision)
+    qubit, mode = op.wires
+    axis, mode_idx = _get_axis_and_index(mode)
+
+    return f"{gate_id} q[{qubit}] {params[0]}"
+
+
+@tokenize_operation.register
+def _(op: native_ops.NativeBeamsplitter, precision: Optional[float] = None):
+    # Has format Beamsplitter <qubit> <detuning1> <detuning2> <duration> <phase>
+    gate_id = BOSON_GATES[op.name]
+    params = _tokenize_params(op.parameters, precision=precision)
+    qubit, *modes = op.wires
+    # axis, mode_idx = _get_axis_and_index(mode)
+
+    return f"{gate_id} q[{qubit}] {params[0]} {params[1]} {params[2]} {params[3]}"
+
+
+def _tokenize_params(params, precision: Optional[float] = None):
+    if precision:
+        params = list(map(lambda p: f"{p:.{precision}}", params))
+    else:
+        params = list(map(str, params))
+
+    return params
+
+
+# Should match layout function in the main device
+qumode_pattern = re.compile(r"^a([01])m(\d+)$")
+
+
+def _get_axis_and_index(qumode):
+    if isinstance(qumode, str) and (match := qumode_pattern.match(qumode)):
+        return int(match.group(1)), int(match.group(2))
+
+    raise DeviceError(f"Unsupported qumode name: {qumode}")

--- a/src/hybridlane/devices/sandia_qscout/ops.py
+++ b/src/hybridlane/devices/sandia_qscout/ops.py
@@ -1,0 +1,263 @@
+# Copyright (c) 2025, Battelle Memorial Institute
+
+# This software is licensed under the 2-Clause BSD License.
+# See the LICENSE.txt file for full license text.
+
+r"""Module containing the native bosonic gates of the ion trap"""
+
+import math
+from typing import Optional
+
+import pennylane as qml
+from pennylane.operation import Operation
+from pennylane.typing import TensorLike
+from pennylane.wires import WiresLike
+
+import hybridlane as hqml
+
+from ...ops.hybrid import Hybrid, _can_replace
+
+
+class ConditionalXDisplacement(Operation, Hybrid):
+    r"""Symmetric conditional displacement gate :math:`C_xD(\alpha)`
+
+    This is the qubit-conditioned version of the :py:class:`~pennylane.ops.cv.Displacement` gate, given by
+
+    .. math::
+
+        CD(\beta) &= \exp[\sigma_x(\beta \ad - \beta^* a)]
+
+    which differs from :class:`~hybridlane.ops.hybrid.ConditionalDisplacement` due to the :math:`\sigma_x` factor
+    instead of :math:`\sigma_z`.
+
+    This is represented by the hardware instruction ``SDF``, and it can only be used on hardware qumode ``a0m1``
+    """
+
+    num_params = 2
+    num_wires = 2
+    num_qumodes = 1
+    grad_method = "F"
+
+    resource_keys = set()
+
+    def __init__(
+        self,
+        beta_re: TensorLike,
+        beta_im: TensorLike,
+        wires: WiresLike,
+        id: Optional[str] = None,
+    ):
+        r"""
+        Args:
+            beta_re: The real part of :math:`\beta`
+
+            beta_im: The imaginary part of :math:`\beta`
+
+            wires: The wires this gate acts on, in the format ``(qubit, qumode)``
+        """
+        super().__init__(beta_re, beta_im, wires=wires, id=id)
+
+    def pow(self, n: int | float):
+        beta_re, beta_im = self.data
+        return [ConditionalXDisplacement(beta_re * n, beta_im * n, self.wires)]
+
+    def adjoint(self):
+        return ConditionalXDisplacement(-self.data[0], -self.data[1], self.wires)
+
+    def simplify(self):
+        beta_re, beta_im = self.data
+
+        if _can_replace(beta_re, 0) and _can_replace(beta_im, 0):
+            return qml.Identity(self.wires)
+
+        return self
+
+    def label(self, decimals=None, base_label=None, cache=None):
+        return super().label(
+            decimals=decimals, base_label=base_label or "SDF", cache=cache
+        )
+
+    @property
+    def resource_params(self):
+        return {}
+
+
+class ConditionalXSqueezing(Operation, Hybrid):
+    r"""Qubit-conditioned squeezing gate :math:`C_xS(\beta)`
+
+    This gate implements the unitary
+
+    .. math::
+
+        CS(\beta) &= \exp\left[\frac{1}{2}\sigma_x (\beta^* a^2 - \beta (\ad)^2)\right]
+
+    which differs from :class:`~hybridlane.ops.hybrid.ConditionalSqueezing` due to the :math:`\sigma_x` factor
+    instead of :math:`\sigma_z`.
+
+    This is represented by the hardware instruction ``RampUp``, and it can only be used on hardware qumode ``a0m1``
+    """
+
+    num_params = 1
+    num_wires = 2
+    num_qumodes = 1
+    grad_method = "F"
+
+    resource_keys = set()
+
+    def __init__(
+        self,
+        ratio: TensorLike,
+        wires: WiresLike,
+        id: Optional[str] = None,
+    ):
+        r"""
+        Args:
+            ratio: The blue/red ratio
+        """
+        super().__init__(ratio, wires=wires, id=id)
+
+    @property
+    def resource_params(self):
+        return {}
+
+    def label(self, decimals=None, base_label=None, cache=None):
+        return super().label(
+            decimals=decimals, base_label=base_label or "RampUp", cache=cache
+        )
+
+
+class SidebandProbe(Operation, Hybrid):
+    r"""General sideband probe operation
+
+    This is represented by the hardware instruction ``Rt_SBProbe``
+    """
+
+    num_params = 4
+    num_wires = 2
+    num_qumodes = 1
+    grad_method = None
+
+    resource_keys = set()
+
+    def __init__(
+        self,
+        duration_us: TensorLike,
+        phase: TensorLike,
+        sign: TensorLike,
+        detuning: TensorLike,
+        wires: WiresLike = None,
+        id: Optional[str] = None,
+    ):
+        super().__init__(duration_us, phase, sign, detuning, wires=wires, id=id)
+
+    def pow(self, n: int | float):
+        duration, *params = self.data
+        return [SidebandProbe(duration * n, *params, wires=self.wires)]
+
+    @property
+    def resource_params(self):
+        return {}
+
+    def label(self, decimals=None, base_label=None, cache=None):
+        return super().label(
+            decimals=decimals, base_label=base_label or "Rt_SBP", cache=cache
+        )
+
+
+FockStatePrep = hqml.FockLadder
+r"""Prepare a definite Fock state
+
+If this is used on the tilt modes (hardware qumodes ``a0m1`` and ``a1m1``), this can
+be represented in terms of a native Jaqal instruction ``FockState``. Otherwise, the
+program will contain custom sequences of Red/Blue sideband gates
+"""
+
+
+class NativeBeamsplitter(Operation, Hybrid):
+    r"""Hardware-native beamsplitter gate
+
+    This class is named NativeBeamsplitter to distinguish it from :class:`~hybridlane.ops.Beamsplitter`,
+    as it has different arguments. It is represented by the hardware instruction ``Beamsplitter``.
+
+    Currently this gate can only be executed on the tilt modes (``a0m1``, ``a1m1``)
+    """
+
+    num_params = 4
+    num_wires = 3
+    num_qumodes = 2
+    grad_method = None
+
+    resource_keys = set()
+
+    def __init__(
+        self,
+        detuning1: TensorLike,
+        detuning2: TensorLike,
+        duration: TensorLike,
+        phase: TensorLike,
+        wires: WiresLike = None,
+        id: Optional[str] = None,
+    ):
+        super().__init__(detuning1, detuning2, duration, phase, wires=wires, id=id)
+
+    @property
+    def resource_params(self):
+        return {}
+
+    def label(self, decimals=None, base_label=None, cache=None):
+        return super().label(
+            decimals=decimals, base_label=base_label or "BS", cache=cache
+        )
+
+
+class R(Operation):
+    r"""Rotation about an axis :math:`R_{\phi}(\theta)`
+
+    .. math::
+
+        R_{\phi}(\theta) = e^{-i\theta/2 (\cos\phi X + \sin\phi Y)}
+    """
+
+    num_params = 2
+    ndim_params = (0, 0)
+    num_wires = 1
+
+    resource_keys = set()
+
+    def __init__(self, theta, phi, wires: WiresLike = None, id: Optional[str] = None):
+        super().__init__(theta, phi, wires=wires, id=id)
+
+    def adjoint(self):
+        return R(-self.data[0], self.data[1], wires=self.wires)
+
+    def pow(self, z):
+        return [R(z * self.data[0], self.data[1], wires=self.wires)]
+
+    @property
+    def resource_params(self):
+        return {}
+
+    def simplify(self):
+        theta, phi = self.data[0] % (2 * math.pi), self.data[1] % math.pi
+
+        if _can_replace(theta, 0):
+            return qml.Identity(wires=self.wires)
+
+        elif _can_replace(phi, 0):
+            return qml.RX(theta, wires=self.wires)
+
+        elif _can_replace(phi, math.pi / 2):
+            return qml.RY(theta, wires=self.wires)
+
+        elif _can_replace(phi, -math.pi):
+            return qml.RX(-theta, wires=self.wires)
+
+        elif _can_replace(phi, -math.pi / 2):
+            return qml.RY(theta, wires=self.wires)
+
+        return R(theta, phi, wires=self.wires)
+
+    def label(self, decimals=None, base_label=None, cache=None):
+        return super().label(
+            decimals=decimals, base_label=base_label or "R", cache=cache
+        )

--- a/src/hybridlane/io/openqasm.py
+++ b/src/hybridlane/io/openqasm.py
@@ -12,7 +12,7 @@ the computational basis in phase space is :math:`\hat{x}`).
     import pennylane as qml
     import hybridlane as hqml
 
-    dev = qml.device("hybrid.bosonicqiskit")
+    dev = qml.device("bosonicqiskit.hybrid")
 
     @qml.qnode(dev)
     def circuit(n):

--- a/src/hybridlane/ops/__init__.py
+++ b/src/hybridlane/ops/__init__.py
@@ -21,7 +21,10 @@ from .cv import (
     TwoModeSum,
 )
 from .hybrid import (
+    SNAP,
+    SQR,
     AntiJaynesCummings,
+    Blue,
     ConditionalBeamsplitter,
     ConditionalDisplacement,
     ConditionalParity,
@@ -31,6 +34,7 @@ from .hybrid import (
     ConditionalTwoModeSum,
     JaynesCummings,
     Rabi,
+    Red,
     SelectiveNumberArbitraryPhase,
     SelectiveQubitRotation,
 )
@@ -51,9 +55,13 @@ __all__ = [
     "Fourier",
     "Hybrid",
     "SelectiveQubitRotation",
+    "SQR",
     "SelectiveNumberArbitraryPhase",
+    "SNAP",
     "JaynesCummings",
+    "Red",
     "AntiJaynesCummings",
+    "Blue",
     "Rabi",
     "ConditionalDisplacement",
     "ConditionalSqueezing",

--- a/src/hybridlane/ops/cv.py
+++ b/src/hybridlane/ops/cv.py
@@ -47,10 +47,16 @@ class Displacement(CVOperation):
         _two_term_shift_rule,
     )
 
+    resource_keys = set()
+
     def __init__(
         self, a: TensorLike, phi: TensorLike, wires: WiresLike, id: Optional[str] = None
     ):
         super().__init__(a, phi, wires=wires, id=id)
+
+    @property
+    def resource_params(self):
+        return {}
 
     @staticmethod
     def _heisenberg_rep(p):
@@ -84,8 +90,14 @@ class Rotation(CVOperation):
     grad_method = "A"
     grad_recipe = (_two_term_shift_rule,)
 
+    resource_keys = set()
+
     def __init__(self, theta: TensorLike, wires: WiresLike, id: Optional[str] = None):
         super().__init__(theta, wires=wires, id=id)
+
+    @property
+    def resource_params(self):
+        return {}
 
     @staticmethod
     def _heisenberg_rep(p):
@@ -129,8 +141,14 @@ class Squeezing(CVOperation):
         _two_term_shift_rule,
     )
 
+    resource_keys = set()
+
     def __init__(self, r, phi, wires, id=None):
         super().__init__(r, phi, wires=wires, id=id)
+
+    @property
+    def resource_params(self):
+        return {}
 
     @staticmethod
     def _heisenberg_rep(p):
@@ -161,8 +179,14 @@ class Kerr(CVOperation):
     num_wires = 1
     grad_method = "F"
 
+    resource_keys = set()
+
     def __init__(self, kappa: TensorLike, wires: WiresLike, id: Optional[str] = None):
         super().__init__(kappa, wires=wires, id=id)
+
+    @property
+    def resource_params(self):
+        return {}
 
     def adjoint(self):
         return Kerr(-self.parameters[0], wires=self.wires)
@@ -193,8 +217,14 @@ class CubicPhase(CVOperation):
     num_wires = 1
     grad_method = "F"
 
+    resource_keys = set()
+
     def __init__(self, r: TensorLike, wires: WiresLike, id: Optional[str] = None):
         super().__init__(r, wires=wires, id=id)
+
+    @property
+    def resource_params(self):
+        return {}
 
     def adjoint(self):
         return CubicPhase(-self.parameters[0], wires=self.wires)
@@ -221,8 +251,14 @@ class Fourier(CVOperation):
     num_params = 0
     num_wires = 1
 
+    resource_keys = set()
+
     def __init__(self, wires: WiresLike, id: Optional[str] = None):
         super().__init__(wires=wires, id=id)
+
+    @property
+    def resource_params(self):
+        return {}
 
     @staticmethod
     def compute_decomposition(
@@ -253,6 +289,8 @@ class Beamsplitter(CVOperation):
     grad_method = "A"
     grad_recipe = (_two_term_shift_rule, _two_term_shift_rule)
 
+    resource_keys = set()
+
     def __init__(
         self,
         theta: TensorLike,
@@ -261,6 +299,10 @@ class Beamsplitter(CVOperation):
         id: Optional[str] = None,
     ):
         super().__init__(theta, phi, wires=wires, id=id)
+
+    @property
+    def resource_params(self):
+        return {}
 
     # For the beamsplitter, both parameters are rotation-like
     # Todo: Redo this with new convention
@@ -313,8 +355,14 @@ class TwoModeSqueezing(CVOperation):
         _two_term_shift_rule,
     )
 
+    resource_keys = set()
+
     def __init__(self, r, phi, wires, id=None):
         super().__init__(r, phi, wires=wires, id=id)
+
+    @property
+    def resource_params(self):
+        return {}
 
     @staticmethod
     def _heisenberg_rep(p):
@@ -368,9 +416,16 @@ class TwoModeSum(CVOperation):
 
     num_params = 1
     num_wires = 2
+    grad_method = "F"
+
+    resource_keys = set()
 
     def __init__(self, lambda_: TensorLike, wires: WiresLike, id: Optional[str] = None):
         super().__init__(lambda_, wires=wires, id=id)
+
+    @property
+    def resource_params(self):
+        return {}
 
     def adjoint(self):
         lambda_ = self.parameters[0]
@@ -409,8 +464,14 @@ class ModeSwap(CVOperation):
     num_params = 0
     num_wires = 2
 
+    resource_keys = set()
+
     def __init__(self, wires: WiresLike, id: Optional[str] = None):
         super().__init__(wires=wires, id=id)
+
+    @property
+    def resource_params(self):
+        return {}
 
     @staticmethod
     def compute_decomposition(*params, wires, **hyperparameters):

--- a/src/hybridlane/ops/hybrid.py
+++ b/src/hybridlane/ops/hybrid.py
@@ -37,8 +37,14 @@ class ConditionalRotation(Operation, Hybrid):
     num_wires = 2
     num_qumodes = 1
 
+    resource_keys = set()
+
     def __init__(self, theta: TensorLike, wires: WiresLike, id: Optional[str] = None):
         super().__init__(theta, wires=wires, id=id)
+
+    @property
+    def resource_params(self):
+        return {}
 
     def adjoint(self):
         theta = self.parameters[0]
@@ -84,6 +90,8 @@ class ConditionalDisplacement(Operation, Hybrid):
     num_wires = 2
     num_qumodes = 1
 
+    resource_keys = set()
+
     def __init__(
         self,
         a: TensorLike,
@@ -92,6 +100,10 @@ class ConditionalDisplacement(Operation, Hybrid):
         id: Optional[str] = None,
     ):
         super().__init__(a, phi, wires=wires, id=id)
+
+    @property
+    def resource_params(self):
+        return {}
 
     def pow(self, z: int | float):
         a, phi = self.data
@@ -137,10 +149,16 @@ class ConditionalSqueezing(Operation, Hybrid):
     num_wires = 2
     num_qumodes = 1
 
+    resource_keys = set()
+
     def __init__(
         self, z: TensorLike, phi: TensorLike, wires: WiresLike, id: Optional[str] = None
     ):
         super().__init__(z, phi, wires=wires, id=id)
+
+    @property
+    def resource_params(self):
+        return {}
 
     def pow(self, n: int | float):
         z, phi = self.data
@@ -185,8 +203,14 @@ class ConditionalParity(Operation, Hybrid):
     num_wires = 2
     num_qumodes = 1
 
+    resource_keys = set()
+
     def __init__(self, wires: WiresLike, id: Optional[str] = None):
         super().__init__(wires=wires, id=id)
+
+    @property
+    def resource_params(self):
+        return {}
 
     @staticmethod
     def compute_decomposition(*params, wires, **hyperparameters):
@@ -224,6 +248,8 @@ class SelectiveQubitRotation(Operation, Hybrid):
     num_wires = 2
     num_qumodes = 1
 
+    resource_keys = set()
+
     def __init__(
         self,
         theta: TensorLike,
@@ -239,6 +265,10 @@ class SelectiveQubitRotation(Operation, Hybrid):
         self.hyperparameters["n"] = n
 
         super().__init__(theta, phi, wires=wires, id=id)
+
+    @property
+    def resource_params(self):
+        return {}
 
     def adjoint(self):
         theta, phi = self.parameters
@@ -276,6 +306,19 @@ class SelectiveQubitRotation(Operation, Hybrid):
         )
 
 
+SQR = SelectiveQubitRotation
+r"""number-Selective Qubit Rotation (SQR) gate`
+
+.. math::
+
+    SQR(\theta, \varphi) = R_{\varphi}(\theta) \otimes \ket{n}\bra{n}
+
+.. seealso::
+
+    This is an alias for :class:`~.SelectiveQubitRotation`
+"""
+
+
 class SelectiveNumberArbitraryPhase(Operation, Hybrid):
     r"""Selective Number-dependent Arbitrary Phase (SNAP) gate :math:`SNAP(\varphi, n)`
 
@@ -307,6 +350,8 @@ class SelectiveNumberArbitraryPhase(Operation, Hybrid):
     num_wires = 2
     num_qumodes = 1
 
+    resource_keys = set()
+
     def __init__(
         self,
         phi: TensorLike,
@@ -319,6 +364,10 @@ class SelectiveNumberArbitraryPhase(Operation, Hybrid):
 
         self.hyperparameters["n"] = n
         super().__init__(phi, wires=wires, id=id)
+
+    @property
+    def resource_params(self):
+        return {}
 
     def adjoint(self):
         phi = self.parameters[0]
@@ -366,6 +415,19 @@ class SelectiveNumberArbitraryPhase(Operation, Hybrid):
         )
 
 
+SNAP = SelectiveNumberArbitraryPhase
+r"""Selective Number-dependent Arbitrary Phase (SNAP) gate
+
+.. math::
+
+    SNAP(\varphi, n) = e^{-i \varphi \sigma_z \ket{n}\bra{n}}
+
+.. seealso::
+
+    This is an alias for :class:`~.SelectiveNumberArbitraryPhase`
+"""
+
+
 class JaynesCummings(Operation, Hybrid):
     r"""Jaynes-cummings gate :math:`JC(\theta, \varphi)`, also known as Red-Sideband
 
@@ -395,6 +457,8 @@ class JaynesCummings(Operation, Hybrid):
     num_wires = 2
     num_qumodes = 1
 
+    resource_keys = set()
+
     def __init__(
         self,
         theta: TensorLike,
@@ -403,6 +467,10 @@ class JaynesCummings(Operation, Hybrid):
         id: Optional[str] = None,
     ):
         super().__init__(theta, phi, wires=wires, id=id)
+
+    @property
+    def resource_params(self):
+        return {}
 
     def simplify(self):
         theta = self.data[0] % (2 * math.pi)
@@ -423,6 +491,19 @@ class JaynesCummings(Operation, Hybrid):
         return super().label(
             decimals=decimals, base_label=base_label or "JC", cache=cache
         )
+
+
+Red = JaynesCummings
+r"""Red sideband gate
+
+.. math::
+
+    JC(\theta, \varphi) = \exp[-i\theta(e^{i\varphi}\sigma_- \ad + e^{-i\varphi}\sigma_+ a)]
+
+.. seealso::
+
+    This is an alias of :class:`~.JaynesCummings`
+"""
 
 
 class AntiJaynesCummings(Operation, Hybrid):
@@ -454,6 +535,8 @@ class AntiJaynesCummings(Operation, Hybrid):
     num_wires = 2
     num_qumodes = 1
 
+    resource_keys = set()
+
     def __init__(
         self,
         theta: TensorLike,
@@ -462,6 +545,10 @@ class AntiJaynesCummings(Operation, Hybrid):
         id: Optional[str] = None,
     ):
         super().__init__(theta, phi, wires=wires, id=id)
+
+    @property
+    def resource_params(self):
+        return {}
 
     def simplify(self):
         theta = self.data[0] % (2 * math.pi)
@@ -484,6 +571,19 @@ class AntiJaynesCummings(Operation, Hybrid):
         )
 
 
+Blue = AntiJaynesCummings
+r"""Blue sideband gate
+
+.. math::
+
+    AJC(\theta, \varphi) = \exp[-i\theta(e^{i\varphi}\sigma_+ \ad + e^{-i\varphi}\sigma_- a)]
+
+.. seealso::
+
+    This is an alias of :class:`~.AntiJaynesCummings`
+"""
+
+
 class Rabi(Operation, Hybrid):
     r"""Rabi interaction :math:`RB(\theta)`
 
@@ -502,10 +602,16 @@ class Rabi(Operation, Hybrid):
     num_wires = 2
     num_qumodes = 1
 
+    resource_keys = set()
+
     def __init__(
         self, r: TensorLike, phi: TensorLike, wires: WiresLike, id: Optional[str] = None
     ):
         super().__init__(r, phi, wires=wires, id=id)
+
+    @property
+    def resource_params(self):
+        return {}
 
     def simplify(self):
         r = self.data[0]
@@ -551,6 +657,8 @@ class ConditionalBeamsplitter(Operation, Hybrid):
     num_wires = 3
     num_qumodes = 2
 
+    resource_keys = set()
+
     def __init__(
         self,
         theta: TensorLike,
@@ -559,6 +667,10 @@ class ConditionalBeamsplitter(Operation, Hybrid):
         id: Optional[str] = None,
     ):
         super().__init__(theta, phi, wires=wires, id=id)
+
+    @property
+    def resource_params(self):
+        return {}
 
     def adjoint(self):
         return ConditionalBeamsplitter(-self.data[0], self.data[1], self.wires)
@@ -608,6 +720,8 @@ class ConditionalTwoModeSqueezing(Operation, Hybrid):
     num_wires = 3
     num_qumodes = 2
 
+    resource_keys = set()
+
     def __init__(
         self,
         r: TensorLike,
@@ -616,6 +730,10 @@ class ConditionalTwoModeSqueezing(Operation, Hybrid):
         id: Optional[str] = None,
     ):
         super().__init__(r, phi, wires=wires, id=id)
+
+    @property
+    def resource_params(self):
+        return {}
 
     def pow(self, z: int | float):
         r, phi = self.data
@@ -661,8 +779,14 @@ class ConditionalTwoModeSum(Operation, Hybrid):
     num_wires = 3
     num_qumodes = 2
 
+    resource_keys = set()
+
     def __init__(self, lam: TensorLike, wires: WiresLike, id: Optional[str] = None):
         super().__init__(lam, wires=wires, id=id)
+
+    @property
+    def resource_params(self):
+        return {}
 
     def adjoint(self):
         lambda_ = self.parameters[0]

--- a/src/hybridlane/templates/__init__.py
+++ b/src/hybridlane/templates/__init__.py
@@ -1,0 +1,3 @@
+from .fock_ladder import FockLadder
+
+__all__ = ["FockLadder"]

--- a/src/hybridlane/templates/fock_ladder.py
+++ b/src/hybridlane/templates/fock_ladder.py
@@ -1,0 +1,45 @@
+import math
+from typing import Optional, cast
+
+from pennylane.ops import Operation
+from pennylane.wires import Wires, WiresLike
+
+from ..ops import Hybrid, Red, Blue
+
+
+class FockLadder(Operation, Hybrid):
+    r"""Prepares a definite Fock state from the vacuum
+
+    Unlike :class:`~pennylane.ops.cv.FockState`, this class uses a sequence of
+    :py:class:`~hybridlane.ops.Red` and :py:class:`~hybridlane.ops.Blue`
+    gates, requiring an ancilla qubit.
+    """
+
+    num_params = 1
+    num_wires = 2
+    num_qumodes = 1
+    grad_method = None
+
+    resource_keys = {"num_gates"}
+
+    def __init__(self, n: int, wires: WiresLike = None, id: Optional[str] = None):
+        super().__init__(n, wires=wires, id=id)
+
+    @property
+    def resource_params(self):
+        n = cast(int, self.parameters[0])
+        return {"num_gates": n}
+
+    @staticmethod
+    def compute_decomposition(*params, wires: Wires, **_):
+        fock_state = cast(int, params[0])
+        decomp = []
+        for n in range(fock_state):
+            rabi_rate = math.sqrt(n + 1)
+            theta = math.pi / (2 * rabi_rate)
+            if n % 2 == 0:
+                decomp.append(Blue(theta, math.pi / 2, wires))
+            else:
+                decomp.append(Red(theta, math.pi / 2, wires))
+
+        return decomp

--- a/test/devices/bosonic_qiskit/test_device.py
+++ b/test/devices/bosonic_qiskit/test_device.py
@@ -38,12 +38,12 @@ class TestBosonicQiskitDevice:
     def test_device_is_registered(self):
         from hybridlane.devices import BosonicQiskitDevice
 
-        dev = qml.device("hybrid.bosonicqiskit")
+        dev = qml.device("bosonicqiskit.hybrid")
         assert isinstance(dev, BosonicQiskitDevice)
 
     def test_non_power_of_two_truncation(self):
         trunc = FockTruncation.all_fock_space([0, 1], {0: 2, 1: 7})
-        dev = qml.device("hybrid.bosonicqiskit", truncation=trunc)
+        dev = qml.device("bosonicqiskit.hybrid", truncation=trunc)
 
         @qml.qnode(dev)
         def circuit():
@@ -56,7 +56,7 @@ class TestBosonicQiskitDevice:
     def test_no_inferrable_truncation(self):
         # This circuit has a qumode that should be detected through static analysis,
         # but no truncation is provided.
-        dev = qml.device("hybrid.bosonicqiskit")
+        dev = qml.device("bosonicqiskit.hybrid")
 
         @qml.qnode(dev)
         def circuit():
@@ -70,7 +70,7 @@ class TestBosonicQiskitDevice:
         # This circuit should be detected as all qubit and therefore automagically
         # derive a truncation of 2 for each qubit. It'll then fail because
         # we only simulate hybrid programs.
-        dev = qml.device("hybrid.bosonicqiskit")
+        dev = qml.device("bosonicqiskit.hybrid")
 
         @qml.qnode(dev)
         def circuit():
@@ -84,10 +84,10 @@ class TestBosonicQiskitDevice:
         trunc = mock.Mock(spec=Truncation)
 
         with pytest.raises(DeviceError):
-            dev = qml.device("hybrid.bosonicqiskit", truncation=trunc)
+            dev = qml.device("bosonicqiskit.hybrid", truncation=trunc)
 
     def test_wires_aliased_by_operation(self):
-        dev = qml.device("hybrid.bosonicqiskit", max_fock_level=8)
+        dev = qml.device("bosonicqiskit.hybrid", max_fock_level=8)
 
         @qml.qnode(dev)
         def circuit():
@@ -109,7 +109,7 @@ class TestBosonicQiskitDevice:
         ),
     )
     def test_wires_aliased_by_observable(self, obs):
-        dev = qml.device("hybrid.bosonicqiskit", max_fock_level=8)
+        dev = qml.device("bosonicqiskit.hybrid", max_fock_level=8)
 
         @qml.qnode(dev)
         def circuit():
@@ -125,7 +125,7 @@ class TestExampleCircuits:
     def test_vacuum_expval(self):
         # The simplest test you could do, checking the vacuum state |0> has <n> = 0
 
-        dev = qml.device("hybrid.bosonicqiskit", max_fock_level=16)
+        dev = qml.device("bosonicqiskit.hybrid", max_fock_level=16)
 
         @qml.qnode(dev)
         def circuit():
@@ -137,7 +137,7 @@ class TestExampleCircuits:
 
     def test_vacuum_var(self):
         # Checking the vacuum state |0> has Var(n) = 0 since it's a definite eigenstate
-        dev = qml.device("hybrid.bosonicqiskit", max_fock_level=16)
+        dev = qml.device("bosonicqiskit.hybrid", max_fock_level=16)
 
         @qml.qnode(dev)
         def circuit():
@@ -148,7 +148,7 @@ class TestExampleCircuits:
         assert np.isclose(result, 0)
 
     def test_heisenberg_uncertainty(self):
-        dev = qml.device("hybrid.bosonicqiskit", max_fock_level=16, hbar=2)
+        dev = qml.device("bosonicqiskit.hybrid", max_fock_level=16, hbar=2)
 
         @qml.qnode(dev)
         def circuit():
@@ -162,7 +162,7 @@ class TestExampleCircuits:
     def test_displacement_analytic(self, alpha):
         # Basic circuit that prepares |α> and checks the mean photon count
         # is <n> = |α|^2
-        dev = qml.device("hybrid.bosonicqiskit", max_fock_level=16)
+        dev = qml.device("bosonicqiskit.hybrid", max_fock_level=16)
 
         @qml.qnode(dev)
         def circuit(alpha):
@@ -180,7 +180,7 @@ class TestExampleCircuits:
         lam = np.abs(alpha) ** 2
         truncation = FockTruncation.all_fock_space([0, 1], {0: 16, 1: 4})
 
-        dev = qml.device("hybrid.bosonicqiskit", truncation=truncation)
+        dev = qml.device("bosonicqiskit.hybrid", truncation=truncation)
 
         @qml.qnode(dev)
         def circuit(alpha):
@@ -202,7 +202,7 @@ class TestExampleCircuits:
         n_per_test = 5000
         repetitions = 10
 
-        dev = qml.device("hybrid.bosonicqiskit", max_fock_level=fock_levels)
+        dev = qml.device("bosonicqiskit.hybrid", max_fock_level=fock_levels)
 
         @partial(qml.set_shots, shots=repetitions * n_per_test)
         @qml.qnode(dev)
@@ -235,7 +235,7 @@ class TestExampleCircuits:
         alpha = 1.5
         truncation = FockTruncation.all_fock_space([0], {0: 16})
 
-        dev = qml.device("hybrid.bosonicqiskit", truncation=truncation)
+        dev = qml.device("bosonicqiskit.hybrid", truncation=truncation)
 
         @qml.qnode(dev)
         def circuit(alpha, phi):
@@ -252,7 +252,7 @@ class TestExampleCircuits:
     @pytest.mark.parametrize("n", range(6))
     def test_create_fock_state_analytic(self, n):
         # Creates the state |0,n> through JC gates
-        dev = qml.device("hybrid.bosonicqiskit", wires=[0, "m0"], max_fock_level=8)
+        dev = qml.device("bosonicqiskit.hybrid", wires=[0, "m0"], max_fock_level=8)
 
         @qml.qnode(dev)
         def circuit():
@@ -267,7 +267,7 @@ class TestExampleCircuits:
         assert np.isclose(expval_z, 1.0)
 
     def test_jc_analytic(self):
-        dev = qml.device("hybrid.bosonicqiskit", max_fock_level=4)
+        dev = qml.device("bosonicqiskit.hybrid", max_fock_level=4)
 
         @qml.qnode(dev)
         def circuit():
@@ -302,7 +302,7 @@ class TestExampleCircuits:
         lam = np.abs(alpha) ** 2
         truncation = FockTruncation.all_fock_space([0], {0: 16})
 
-        dev = qml.device("hybrid.bosonicqiskit", truncation=truncation)
+        dev = qml.device("bosonicqiskit.hybrid", truncation=truncation)
 
         @qml.qnode(dev)
         def circuit(alpha):
@@ -315,7 +315,7 @@ class TestExampleCircuits:
         assert np.isclose(n, expval_n + expval_n2)
 
     def test_cv_swap(self):
-        dev = qml.device("hybrid.bosonicqiskit", max_fock_level=16)
+        dev = qml.device("bosonicqiskit.hybrid", max_fock_level=16)
 
         @qml.qnode(dev)
         def circuit(alpha):
@@ -342,7 +342,7 @@ class TestExampleCircuits:
         lam = np.abs(alpha) ** 2
         truncation = FockTruncation.all_fock_space([0], {0: 16})
 
-        dev = qml.device("hybrid.bosonicqiskit", truncation=truncation)
+        dev = qml.device("bosonicqiskit.hybrid", truncation=truncation)
 
         @qml.qnode(dev)
         def circuit(alpha):
@@ -363,7 +363,7 @@ class TestExampleCircuits:
         n_per_test = 5000
         repetitions = 10
 
-        dev = qml.device("hybrid.bosonicqiskit", max_fock_level=fock_levels)
+        dev = qml.device("bosonicqiskit.hybrid", max_fock_level=fock_levels)
 
         @partial(qml.set_shots, shots=repetitions * n_per_test)
         @qml.qnode(dev)

--- a/test/devices/qscout/test_device.py
+++ b/test/devices/qscout/test_device.py
@@ -1,0 +1,247 @@
+from collections import Counter
+from functools import partial
+
+import pennylane as qml
+import pytest
+from pennylane.decomposition import DecompositionError
+from pennylane.exceptions import DeviceError
+from pennylane.workflow import construct_tape
+
+import hybridlane as hqml
+from hybridlane import sa
+from hybridlane.devices.sandia_qscout import QscoutIonTrap
+from hybridlane.devices.sandia_qscout import ops as ion
+from pennylane.wires import Wires
+
+qml.decomposition.enable_graph()
+
+
+class TestDevice:
+    @pytest.mark.parametrize("allow_com", (True, False))
+    def test_com_modes(self, allow_com):
+        dev = QscoutIonTrap(use_com_modes=allow_com, use_hardware_wires=True)
+
+        qubits = dev._max_qubits
+
+        if allow_com:
+            qumodes = 2 * qubits
+        else:
+            qumodes = 2 * qubits - 2
+            assert len(dev.wires & ["a0m0", "a1m0"]) == 0
+
+        assert len(dev.wires) == qubits + qumodes
+
+    @pytest.mark.parametrize(
+        "obs",
+        (
+            qml.X(0) @ qml.X(1),
+            qml.X(0) @ qml.Y(3) @ qml.Z(1),
+            qml.Z(0),
+            qml.s_prod(0.5, qml.Z(0) @ qml.X(1)),
+        ),
+    )
+    def test_supported_sample_observable(self, obs):
+        dev = QscoutIonTrap()
+
+        @partial(qml.set_shots, shots=20)
+        @qml.qnode(dev)
+        def circuit(obs):
+            return hqml.var(obs)
+
+        circuit(obs)
+
+    @pytest.mark.parametrize(
+        "obs",
+        (
+            qml.X(0) @ qml.X(1),
+            qml.X(0) @ qml.Y(3) @ qml.Z(1),
+            qml.Z(0),
+            qml.s_prod(0.5, qml.Z(0) @ qml.X(1)),
+        ),
+    )
+    def test_no_analytic_measurement(self, obs):
+        dev = QscoutIonTrap()
+
+        @qml.qnode(dev)
+        def circuit(obs):
+            return hqml.expval(obs)
+
+        with pytest.raises(DeviceError):
+            circuit(obs)
+
+    @pytest.mark.parametrize(
+        "wires, allowed",
+        (
+            ([0, "a0m1", "a0m2"], False),
+            ([0, "a0m3", "a0m1"], False),
+            ([0, "a0m1", "a1m1"], True),
+            ([1, "a0m1", "a1m1"], True),
+            ([2, "a0m1", "a1m1"], True),
+        ),
+    )
+    def test_beamsplitter_constraints(self, wires, allowed):
+        dev = QscoutIonTrap()
+
+        @partial(qml.set_shots, shots=10)
+        @qml.qnode(dev)
+        def circuit(bs_wires):
+            ion.NativeBeamsplitter(1, 2, 3, 4, wires=bs_wires)
+            return hqml.expval(qml.Z(0))
+
+        if allowed:
+            circuit(wires)
+        else:
+            with pytest.raises(DeviceError):
+                circuit(wires)
+
+    @pytest.mark.parametrize(
+        "wires, allowed",
+        (
+            ([0, "a0m1"], True),
+            ([1, "a0m1"], True),
+            ([2, "a0m1"], True),
+            ([0, "a0m3"], False),
+            ([0, "a1m2"], False),
+            ([0, "a1m1"], False),
+        ),
+    )
+    def test_rampup_constraints(self, wires, allowed):
+        dev = QscoutIonTrap()
+
+        @partial(qml.set_shots, shots=10)
+        @qml.qnode(dev)
+        def circuit(wires):
+            ion.ConditionalXSqueezing(0.5, wires=wires)
+            return hqml.expval(qml.Z(0))
+
+        if allowed:
+            circuit(wires)
+        else:
+            with pytest.raises(DeviceError):
+                circuit(wires)
+
+    def too_many_qubits(self):
+        dev = QscoutIonTrap()
+
+        @partial(qml.set_shots, shots=10)
+        @qml.qnode(dev)
+        def circuit():
+            for i in range(dev._max_qubits):
+                qml.H(i)
+            return hqml.expval(qml.Z(0))
+
+        with pytest.raises(DeviceError):
+            circuit()
+
+    def too_many_qumodes(self):
+        dev = QscoutIonTrap()
+
+        @partial(qml.set_shots, shots=10)
+        @qml.qnode(dev)
+        def circuit():
+            for i in range(2 * dev._max_qubits - 2 + 1):
+                hqml.Blue(0.5, 0.5, [0, i + 1])
+            return hqml.expval(qml.Z(0))
+
+        with pytest.raises(DeviceError):
+            circuit()
+
+
+class TestLayout:
+    def test_qumode_assignment(self):
+        dev = QscoutIonTrap()
+
+        @partial(qml.set_shots, shots=10)
+        @qml.qnode(dev)
+        def circuit():
+            for i in range(5):
+                hqml.Blue(0.5, 0, wires=[0, i + 1])
+            return hqml.expval(qml.Z(0))
+
+        tape = construct_tape(circuit, level="device")()
+        sa_res = sa.analyze(tape)
+
+        assert sa_res.qumodes == Wires(["a0m1", "a1m1", "a0m2", "a1m2", "a0m3"])
+
+    def test_qumode_assignment_with_com(self):
+        dev = QscoutIonTrap(use_com_modes=True)
+
+        @partial(qml.set_shots, shots=10)
+        @qml.qnode(dev)
+        def circuit():
+            for i in range(5):
+                hqml.Blue(0.5, 0, wires=[0, i + 1])
+            return hqml.expval(qml.Z(0))
+
+        tape = construct_tape(circuit, level="device")()
+        sa_res = sa.analyze(tape)
+
+        assert sa_res.qumodes == Wires(["a0m0", "a1m0", "a0m1", "a1m1", "a0m2"])
+
+
+class TestDecomposition:
+    def test_fockladder_and_conditionaldisplacement(self):
+        dev = qml.device("sandiaqscout.hybrid", optimize=True)
+
+        @partial(qml.set_shots, shots=20)
+        @qml.qnode(dev)
+        def circuit():
+            hqml.FockLadder(5, [0, "a1m1"])
+            hqml.FockLadder(5, [0, "a1m2"])
+            hqml.ConditionalDisplacement(0.5, 0.5, [0, "a0m1"])
+            hqml.ConditionalDisplacement(-0.5, -0.5, [0, "a0m1"])
+            return hqml.expval(qml.X(0))
+
+        tape = construct_tape(circuit, level="device")()
+        op_counts = Counter([type(op) for op in tape.operations])
+
+        # First FockLadder has a native instruction, so it should be left alone
+        assert op_counts[hqml.FockLadder] == 1
+        assert isinstance(tape.operations[0], hqml.FockLadder)
+
+        # Second one is non-native and should be turned into red/blue sideband pulses
+        op_types = {type(op) for op in tape.operations[1:6]}
+        assert op_types == {hqml.Red, hqml.Blue}
+
+        # Check the conditional displacements got turned into SDF instructions
+        assert op_counts[ion.ConditionalXDisplacement] == 2
+
+    def test_cnot_to_xx(self):
+        dev = qml.device("sandiaqscout.hybrid")
+
+        @partial(qml.set_shots, shots=20)
+        @qml.qnode(dev)
+        def circuit():
+            qml.H(0)
+            qml.CNOT([0, 1])
+            return hqml.expval(qml.X(0))
+
+        tape = construct_tape(circuit, level="device")()
+        op_counts = Counter([type(op) for op in tape.operations])
+        assert op_counts[qml.IsingXX] == 1
+
+    def test_no_beamsplitter_decomposition(self):
+        dev = qml.device("sandiaqscout.hybrid", optimize=True)
+
+        @partial(qml.set_shots, shots=20)
+        @qml.qnode(dev)
+        def circuit():
+            # Hybridlane Beamsplitter gate isn't defined, instead one has to use NativeBeamsplitter
+            hqml.ModeSwap(wires=["a0m1", "a1m3"])
+            return hqml.expval(qml.Z(0))
+
+        with pytest.raises(DecompositionError):
+            construct_tape(circuit, level="device")()
+
+    def test_no_squeezing_decomposition(self):
+        dev = qml.device("sandiaqscout.hybrid", optimize=True)
+
+        @partial(qml.set_shots, shots=20)
+        @qml.qnode(dev)
+        def circuit():
+            # Hybridlane Beamsplitter gate isn't defined, instead one has to use NativeBeamsplitter
+            hqml.ConditionalSqueezing(1, 0, wires=[0, "a0m1"])
+            return hqml.expval(qml.Z(0))
+
+        with pytest.raises(DecompositionError):
+            construct_tape(circuit, level="device")()

--- a/test/devices/qscout/test_jaqal.py
+++ b/test/devices/qscout/test_jaqal.py
@@ -1,0 +1,99 @@
+import math
+from collections import Counter
+from functools import partial
+import textwrap
+
+import pennylane as qml
+import pytest
+from pennylane.decomposition import DecompositionError
+from pennylane.exceptions import DeviceError
+from pennylane.workflow import construct_tape
+
+import hybridlane as hqml
+from hybridlane.devices.sandia_qscout import QscoutIonTrap, to_jaqal
+from hybridlane.devices.sandia_qscout import ops as ion
+from hybridlane.devices.sandia_qscout.jaqal import tokenize_operation
+
+qml.decomposition.enable_graph()
+
+
+class TestTokenizer:
+    def test_fockstate(self):
+        op = ion.FockStatePrep(5, wires=[0, "a0m1"])
+        assert tokenize_operation(op) == "FockState q[0] 5 0"
+
+    def test_beamsplitter(self):
+        op = ion.NativeBeamsplitter(1.0, 2.0, 3.0, 4.0, wires=[0, "a0m1", "a1m1"])
+        assert (
+            tokenize_operation(op, precision=3) == "Beamsplitter q[0] 1.0 2.0 3.0 4.0"
+        )
+
+    def test_blue_sideband(self):
+        op = hqml.Blue(0.5, -0.2, wires=[1, "a1m3"])
+        assert tokenize_operation(op, precision=3) == "Blue q[1] 1 -0.2 0.5 1 3"
+
+    def test_red_sideband(self):
+        op = hqml.Red(0.5, -0.2, wires=[1, "a1m3"])
+        assert tokenize_operation(op, precision=3) == "Red q[1] 1 -0.2 0.5 1 3"
+
+    def test_sideband_probe(self):
+        op = ion.SidebandProbe(0.1, 0.2, 0, 0.3, wires=[0, "a0m1"])
+        assert (
+            tokenize_operation(op, precision=3) == "Rt_SBProbe q[0] 0.2 0.1 0 1 0 0.3"
+        )
+
+    def test_spin_dependent_force(self):
+        op = ion.ConditionalXDisplacement(0.1, -0.23, wires=[3, "a0m1"])
+        assert tokenize_operation(op, precision=3) == "SDF q[3] 0.1 -0.23"
+
+    def test_rampup(self):
+        op = ion.ConditionalXSqueezing(0.2, wires=[0, "a0m1"])
+        assert tokenize_operation(op, precision=3) == "RampUp q[0] 0.2"
+
+    def test_sdg(self):
+        op = qml.adjoint(qml.S(0))
+        assert tokenize_operation(op) == "Szd q[0]"
+
+    def test_sxdg(self):
+        op = qml.adjoint(qml.SX(0))
+        assert tokenize_operation(op) == "Sxd q[0]"
+
+    def test_xx(self):
+        op = qml.IsingXX(0.5, wires=[0, 1])
+        assert tokenize_operation(op, precision=3) == "XX q[0] q[1] 0.5"
+
+    def test_r(self):
+        op = ion.R(0.5, math.pi, wires=0)
+        assert tokenize_operation(op, precision=3) == "R q[0] 3.14 0.5"
+
+
+class TestToJaqal:
+    def test_sample_circuit(self):
+        dev = QscoutIonTrap()
+
+        @partial(qml.set_shots, shots=20)
+        @qml.qnode(dev)
+        def circuit():
+            qml.H(0)
+            qml.CNOT([0, 1])
+            return hqml.expval(qml.X(0))
+
+        program = to_jaqal(circuit, level="device", precision=3)()
+        assert (
+            program
+            == textwrap.dedent(
+                r"""
+            register q[2]
+
+            prepare_all
+            Rz q[0] 3.14
+            Ry q[0] 3.14
+            XX q[0] q[1] 1.57
+            Rx q[1] 11.0
+            Rz q[0] 7.85
+            Ry q[0] 1.57
+            Rz q[0] 1.57
+
+            measure_all"""
+            ).strip()
+        )

--- a/test/draw/test_draw_mpl.py
+++ b/test/draw/test_draw_mpl.py
@@ -15,7 +15,7 @@ from hybridlane.drawer.tape_mpl import default_qubit_color, default_qumode_color
 from hybridlane.drawer.mpldrawer import icon_face_color  # noqa: E402
 
 
-dev = qml.device("hybrid.bosonicqiskit")
+dev = qml.device("bosonicqiskit.hybrid")
 
 
 @qml.qnode(dev)

--- a/test/io/test_openqasm.py
+++ b/test/io/test_openqasm.py
@@ -19,7 +19,7 @@ def evaluate_openqasm_compliance(s: str):
 class TestCircuits:
     @pytest.mark.parametrize("strict", (True, False))
     def test_with_nondiagonal_measurement(self, strict):
-        dev = qml.device("hybrid.bosonicqiskit")
+        dev = qml.device("bosonicqiskit.hybrid")
 
         @qml.qnode(dev)
         def circuit(n):
@@ -54,7 +54,7 @@ class TestCircuits:
 
     @pytest.mark.parametrize("strict", (True, False))
     def test_with_noncommuting_measurements(self, strict):
-        dev = qml.device("hybrid.bosonicqiskit")
+        dev = qml.device("bosonicqiskit.hybrid")
 
         @qml.qnode(dev)
         def circuit(n):
@@ -94,7 +94,7 @@ class TestCircuits:
 
     @pytest.mark.parametrize("strict", (True, False))
     def test_with_pennylane_gate(self, strict):
-        dev = qml.device("hybrid.bosonicqiskit")
+        dev = qml.device("bosonicqiskit.hybrid")
 
         @qml.qnode(dev)
         def circuit():


### PR DESCRIPTION
The Sandia QScout ion trap is added with its native gate set and decompositions, plus a `to_jaqal` function to support exporting the circuits to their format.

Other changes:
 - Renames the bosonic qiskit device to `bosonicqiskit.hybrid`
 - Simplfies the `from_pennylane` transform using singledispatch
 - Makes our gates compatible with new pennylane graph decomposition
 - Introduces the FockLadder template

Thanks @cmortiz for getting started on Jaqal functionality. This is an alternative implementation to #1, but differs by
 - Covering all the supported qubit gates
 - Adding implementations of the bosonic gates
 - Creating the `QscoutIonTrap` as a device that can decompose and optimize circuits
 - Keeps the `to_jaqal` function inside the `qscout` module because it's not a general-purpose IR but is targeted for the ion trap

Closes #8