### PR TITLE
State preparation routines

### DIFF
--- a/src/hybridlane/devices/bosonic_qiskit/device.py
+++ b/src/hybridlane/devices/bosonic_qiskit/device.py
@@ -10,7 +10,7 @@
 import importlib.util
 from collections.abc import Sequence
 from dataclasses import replace
-from typing import Hashable
+from typing import Hashable, Literal
 
 from pennylane.devices import Device
 from pennylane.devices.execution_config import ExecutionConfig
@@ -109,10 +109,10 @@ class BosonicQiskitDevice(Device):
 
     name = "Bosonic Qiskit"  # type: ignore
     shortname = "bosonic-qiskit"
-    version = "0.2.0"
+    version = "0.2.1"
     author = "PNNL"
 
-    _device_options = ("truncation", "hbar")
+    _device_options = ("truncation", "hbar", "units")
 
     def __init__(
         self,
@@ -120,21 +120,22 @@ class BosonicQiskitDevice(Device):
         shots: int | None = None,
         max_fock_level: int | None = None,
         truncation: FockTruncation | None = None,
-        hbar: float = 2,
+        hbar: float = 1,
+        units: Literal["standard", "wigner"] = "standard",
     ):
         r"""Initializes the device
 
         Args:
-            wires: An optional list of wires to expect in each circuit. If this is passed, then executing
-                a circuit will error if it has any wire not in `wires`
+            wires: An optional list of wires to expect in each circuit. If this is passed,
+                then executing a circuit will error if it has any wire not in `wires`
 
-            shots: The number of shots to use for a measurement. If `None` (the default), this performs
-                analytic measurements
+            shots: The number of shots to use for a measurement. If `None` (the default),
+                this performs analytic measurements
 
             max_fock_level: The cutoff to apply uniformly across all qumodes.
 
-            truncation: An optional truncation that allows for more granular cutoffs specified per-qumode.
-                This must be passed if `max_fock_level` is None.
+            truncation: An optional truncation that allows for more granular cutoffs
+                specified per-qumode. This must be passed if `max_fock_level` is None.
 
             hbar: The value for the constant :math:`\bar{h}`.
         """
@@ -148,6 +149,7 @@ class BosonicQiskitDevice(Device):
         self._truncation = truncation
         self._max_fock_level = max_fock_level
         self._hbar = hbar
+        self._units = units
 
         super().__init__(wires=wires, shots=shots)
 
@@ -178,8 +180,13 @@ class BosonicQiskitDevice(Device):
         else:
             truncations = [truncation] * len(circuits)
 
+        hbar = execution_config.device_options.get("hbar", self._hbar)
+        units = execution_config.device_options.get("units", self._units)
+        if units == "wigner":
+            hbar /= 2
+
         return tuple(
-            simulate(tape, truncation, hbar=self._hbar)
+            simulate(tape, truncation, hbar=hbar)
             for tape, truncation in zip(circuits, truncations)
         )
 

--- a/src/hybridlane/devices/bosonic_qiskit/gates.py
+++ b/src/hybridlane/devices/bosonic_qiskit/gates.py
@@ -76,6 +76,7 @@ misc_gate_map = {"Barrier": "barrier"}
 
 # These require special handling so there's no clean mapping to a bosonic qiskit method
 state_prep_routines = {
+    "BasisState",
     "CatState",
     "CoherentState",
     "FockStateVector",

--- a/src/hybridlane/devices/bosonic_qiskit/gates.py
+++ b/src/hybridlane/devices/bosonic_qiskit/gates.py
@@ -74,8 +74,24 @@ hybrid_gate_map: dict[str, str | None] = {
 
 misc_gate_map = {"Barrier": "barrier"}
 
-supported_operations = set(
-    k
-    for k, v in (dv_gate_map | cv_gate_map | hybrid_gate_map | misc_gate_map).items()
-    if v is not None
+# These require special handling so there's no clean mapping to a bosonic qiskit method
+state_prep_routines = {
+    "CatState",
+    "CoherentState",
+    # "FockState",
+    "FockStateVector",
+    "GaussianState",
+    "SqueezedState",
+    "StatePrep",
+}
+
+supported_operations = (
+    set(
+        k
+        for k, v in (
+            dv_gate_map | cv_gate_map | hybrid_gate_map | misc_gate_map
+        ).items()
+        if v is not None
+    )
+    | state_prep_routines
 )

--- a/src/hybridlane/devices/bosonic_qiskit/gates.py
+++ b/src/hybridlane/devices/bosonic_qiskit/gates.py
@@ -78,10 +78,7 @@ misc_gate_map = {"Barrier": "barrier"}
 state_prep_routines = {
     "CatState",
     "CoherentState",
-    # "FockState",
     "FockStateVector",
-    "GaussianState",
-    "SqueezedState",
     "StatePrep",
 }
 

--- a/src/hybridlane/devices/bosonic_qiskit/simulate.py
+++ b/src/hybridlane/devices/bosonic_qiskit/simulate.py
@@ -452,6 +452,19 @@ def _(op: qml.StatePrep, qc: bq.CVCircuit, regmapper: RegisterMapping):
     qc.initialize(state, qubits=qubits)
 
 
+@apply_gate.register
+def _(op: qml.BasisState, qc: bq.CVCircuit, regmapper: RegisterMapping):
+    # This uses the bitmask invocation of initialize
+    bitstring = op.parameters[0]
+    state = np.dot(bitstring, 2 ** np.arange(len(op.wires), dtype=int))
+    state = int(state)
+
+    # No flipping because our conversion to binary above used the little endian form with
+    # wire 0 being the LSB
+    qubits = [regmapper.get(w) for w in op.wires]
+    qc.initialize(state, qubits=qubits)
+
+
 def pad_statevector_to_truncation(
     state: np.ndarray, regmapper: RegisterMapping, wires: Wires
 ) -> np.ndarray:

--- a/src/hybridlane/devices/bosonic_qiskit/simulate.py
+++ b/src/hybridlane/devices/bosonic_qiskit/simulate.py
@@ -11,7 +11,7 @@ import bosonic_qiskit as bq
 import numpy as np
 import pennylane as qml
 from pennylane.exceptions import DeviceError
-from pennylane.operation import Operator
+from pennylane.operation import Operation, Operator
 from pennylane.ops import Exp, Pow, Prod, SProd, Sum
 from pennylane.ops.cv import CVOperation
 from pennylane.tape import QuantumScript
@@ -23,6 +23,7 @@ from qiskit.result import Result as QiskitResult
 from scipy import sparse as sp
 from scipy.linalg import expm, fractional_matrix_power
 from scipy.sparse import SparseEfficiencyWarning, csc_array
+from scipy.special import factorial
 
 import hybridlane as hqml
 
@@ -37,11 +38,15 @@ from ...measurements import (
     VarianceMP,
 )
 from ...ops.mixins import Hybrid
-from .gates import cv_gate_map, dv_gate_map, hybrid_gate_map, misc_gate_map
+from .gates import (
+    cv_gate_map,
+    dv_gate_map,
+    hybrid_gate_map,
+)
 from .register_mapping import RegisterMapping
 
 # Patch to flip the conventions from |g> = |1>, |e> = |0> to |g> = |0>, |e> = |1>
-bq.operators.SMINUS[:] = bq.operators.SMINUS.T
+bq.operators.SMINUS[:] = bq.operators.SMINUS.T  # pyright: ignore[reportAttributeAccessIssue]
 bq.operators.SPLUS[:] = bq.operators.SPLUS.T
 
 
@@ -267,6 +272,13 @@ def make_cv_circuit(
     tape: QuantumScript, truncation: FockTruncation
 ) -> tuple[bq.CVCircuit, RegisterMapping]:
     res = sa.analyze(tape)
+
+    if not res.qumodes:
+        raise DeviceError(
+            "Bosonic qiskit requires at least one qumode to run. No qumodes were detected in "
+            "the circuit."
+        )
+
     regmapper = RegisterMapping(res, truncation)
     for wire, dim in regmapper.truncation.dim_sizes.items():
         if not (qubits := math.log2(dim)).is_integer():
@@ -274,13 +286,7 @@ def make_cv_circuit(
                 f"Only Fock powers of 2 are currently supported on this device, got {dim} on wire {wire} (log2: {qubits})"
             )
 
-    try:
-        qc = bq.CVCircuit(*regmapper.regs)
-    except ValueError as e:
-        raise DeviceError(
-            "Bosonic qiskit currently doesn't support executing circuits without a qumode."
-        ) from e
-
+    qc = bq.CVCircuit(*regmapper.regs)
     for op in tape.operations:
         # Validate that we have actual values in the parameters
         for p in op.parameters:
@@ -289,89 +295,190 @@ def make_cv_circuit(
                     "Need instantiated tensors to convert to qiskit. Circuit may contain Jax or TensorFlow tracing tensors."
                 )
 
-        apply_gate(qc, regmapper, op)
+        apply_gate(op, qc, regmapper)
 
     return qc, regmapper
 
 
-def apply_gate(qc: bq.CVCircuit, regmapper: RegisterMapping, op: Operator):
-    wires = op.wires
+@functools.singledispatch
+def apply_gate(op: Operation, qc: bq.CVCircuit, regmapper: RegisterMapping):
+    if (method := dv_gate_map.get(op.name)) is None:
+        raise DeviceError(
+            f"Unsupported operation {op.name}. Either it's not supported by "
+            "Bosonic Qiskit or it wasn't captured by other branches of this function."
+        )
 
-    if method := dv_gate_map.get(op.name):
-        qubits = [regmapper.get(w) for w in wires]
+    qubits = [regmapper.get(w) for w in op.wires]
 
-        match op:
-            # This is equivalent up to a global phase of e^{-i(φ + ω)/2}
-            case qml.Rot(parameters=(phi, theta, omega)):
-                getattr(qc, method)(
-                    theta, phi, omega, *qubits
-                )  # note the reordered parameters
-            case _:
-                getattr(qc, method)(*op.parameters, *qubits)
+    match op:
+        # This is equivalent up to a global phase of e^{-i(φ + ω)/2}
+        case qml.Rot(parameters=(phi, theta, omega)):
+            getattr(qc, method)(
+                theta, phi, omega, *qubits
+            )  # note the reordered parameters
+        case _:
+            getattr(qc, method)(*op.parameters, *qubits)
 
-    elif isinstance(op, CVOperation) and (method := cv_gate_map.get(op.name)):
-        qumodes = [regmapper.get(w) for w in wires]
 
-        match op:
-            # These gates take complex parameters or differ from bosonic qiskit
-            case hqml.Displacement(parameters=(r, phi)):
-                arg = r * np.exp(1j * phi)
-                getattr(qc, method)(arg, *qumodes)
-            case hqml.Squeezing(parameters=(r, phi)):
-                arg = -r * np.exp(-1j * phi)
-                getattr(qc, method)(arg, *qumodes)
-            case hqml.Rotation(parameters=(theta,)):
-                getattr(qc, method)(-theta, *qumodes)
-            case hqml.Beamsplitter(parameters=(theta, phi)):
-                new_theta = theta / 2
-                new_phi = phi - np.pi / 2
-                z = new_theta * np.exp(1j * new_phi)
-                getattr(qc, method)(z, *qumodes)
-            case hqml.TwoModeSqueezing(parameters=(r, phi)):
-                new_phi = phi + np.pi / 2
-                z = r * np.exp(1j * new_phi)
-                getattr(qc, method)(z, *qumodes)
-            case hqml.SNAP(parameters=parameters, hyperparameters={"n": n}):
-                getattr(qc, method)(*parameters, n, *qumodes)
-            case _:
-                getattr(qc, method)(*op.parameters, *qumodes)
+@apply_gate.register
+def _(op: CVOperation, qc: bq.CVCircuit, regmapper: RegisterMapping):
+    if (method := cv_gate_map.get(op.name)) is None:
+        raise DeviceError(
+            f"Unsupported CV operation {op.name}. This likely means the operation is not "
+            "supported by bosonic qiskit or we forgot to add it to the cv_gate_map."
+        )
 
-    elif isinstance(op, Hybrid) and (method := hybrid_gate_map.get(op.name)):
-        wire_types = op.wire_types()
+    qumodes = [regmapper.get(w) for w in op.wires]
 
-        qumodes = [regmapper.get(w) for w in op.wires if wire_types[w] == sa.Qumode()]
-        qubits = [regmapper.get(w) for w in op.wires if wire_types[w] == sa.Qubit()]
+    match op:
+        # These gates take complex parameters or differ from bosonic qiskit
+        case hqml.Displacement(parameters=(r, phi)):
+            arg = r * np.exp(1j * phi)
+            getattr(qc, method)(arg, *qumodes)
+        case hqml.Squeezing(parameters=(r, phi)):
+            arg = -r * np.exp(-1j * phi)
+            getattr(qc, method)(arg, *qumodes)
+        case hqml.Rotation(parameters=(theta,)):
+            getattr(qc, method)(-theta, *qumodes)
+        case hqml.Beamsplitter(parameters=(theta, phi)):
+            new_theta = theta / 2
+            new_phi = phi - np.pi / 2
+            z = new_theta * np.exp(1j * new_phi)
+            getattr(qc, method)(z, *qumodes)
+        case hqml.TwoModeSqueezing(parameters=(r, phi)):
+            new_phi = phi + np.pi / 2
+            z = r * np.exp(1j * new_phi)
+            getattr(qc, method)(z, *qumodes)
+        case hqml.SNAP(parameters=parameters, hyperparameters={"n": n}):
+            getattr(qc, method)(*parameters, n, *qumodes)
+        case _:
+            getattr(qc, method)(*op.parameters, *qumodes)
 
-        match op:
-            case hqml.ConditionalRotation(parameters=(theta,)):
-                getattr(qc, method)(-theta / 2, *qumodes, *qubits)
-            case (
-                hqml.ConditionalDisplacement(parameters=(r, phi))
-                | hqml.ConditionalSqueezing(parameters=(r, phi))
-            ):
-                arg = r * np.exp(1j * phi)
-                getattr(qc, method)(arg, *qumodes, *qubits)
-            case hqml.SQR(parameters=parameters, hyperparameters={"n": n}):
-                getattr(qc, method)(*parameters, n, *qumodes, *qubits)
-            case hqml.ConditionalBeamsplitter(parameters=(theta, phi)):
-                new_theta = theta / 2
-                new_phi = phi - np.pi / 2
-                z = new_theta * np.exp(1j * new_phi)
-                getattr(qc, method)(z, *qumodes)
-            case hqml.ConditionalTwoModeSqueezing(parameters=(r, phi)):
-                new_phi = phi + np.pi / 2
-                z = r * np.exp(1j * new_phi)
-                getattr(qc, method)(z, *qumodes, *qubits)
-            case _:
-                getattr(qc, method)(*op.parameters, *qumodes, *qubits)
 
-    elif method := misc_gate_map.get(op.name):
-        match op:
-            case qml.Barrier():
-                pass  # no-op
+@apply_gate.register
+def _(op: Hybrid, qc: bq.CVCircuit, regmapper: RegisterMapping):
+    assert isinstance(op, Operation)
 
-    else:
-        raise DeviceError(f"Unsupported operation {op.name}")
+    if (method := hybrid_gate_map.get(op.name)) is None:
+        raise DeviceError(
+            f"Unsupported hybrid operation {op.name}. This likely means the operation is not "
+            "supported by bosonic qiskit or we forgot to add it to the hybrid_gate_map."
+        )
+
+    wire_types = op.wire_types()
+
+    qumodes = [regmapper.get(w) for w in op.wires if wire_types[w] == sa.Qumode()]
+    qubits = [regmapper.get(w) for w in op.wires if wire_types[w] == sa.Qubit()]
+
+    match op:
+        case hqml.ConditionalRotation(parameters=(theta,)):
+            getattr(qc, method)(-theta / 2, *qumodes, *qubits)
+        case hqml.ConditionalDisplacement(parameters=(r, phi)):
+            arg = r * np.exp(1j * phi)
+            getattr(qc, method)(arg, *qumodes, *qubits)
+        case hqml.ConditionalSqueezing(parameters=(r, phi)):
+            arg = -r * np.exp(-1j * phi)
+            getattr(qc, method)(arg, *qumodes, *qubits)
+        case hqml.SQR(parameters=parameters, hyperparameters={"n": n}):
+            getattr(qc, method)(*parameters, n, *qumodes, *qubits)
+        case hqml.ConditionalBeamsplitter(parameters=(theta, phi)):
+            new_theta = theta / 2
+            new_phi = phi - np.pi / 2
+            z = new_theta * np.exp(1j * new_phi)
+            getattr(qc, method)(z, *qumodes)
+        case hqml.ConditionalTwoModeSqueezing(parameters=(r, phi)):
+            new_phi = phi + np.pi / 2
+            z = r * np.exp(1j * new_phi)
+            getattr(qc, method)(z, *qumodes)
+        case _:
+            getattr(qc, method)(*op.parameters, *qumodes, *qubits)
+
+
+@apply_gate.register
+def _(op: qml.Barrier, qc: bq.CVCircuit, regmapper: RegisterMapping):
+    pass  # no-op
+
+
+@apply_gate.register
+def _(op: qml.FockStateVector, qc: bq.CVCircuit, regmapper: RegisterMapping):
+    # State if following the pennylane docs, should be a tensor of shape (N,) * M where N
+    # is the Fock cutoff and M is the number of wires. Since it doesn't appear like that
+    # gets validated, it could be a tensor of shape (n_1, ..., n_m)
+    state = op.parameters[0]
+    state = pad_statevector_to_truncation(state, regmapper, op.wires)
+    ket = qml.math.flatten(state)
+
+    # Since qiskit takes backwards wire ordering compared to pennylane, let's just flip
+    # the order of the qubits instead of the statevector 🧠
+    qubits = []
+    for w in reversed(op.wires):
+        qubits.extend(regmapper.get(w))
+
+    qc.initialize(ket, qubits=qubits)
+
+
+@apply_gate.register
+def _(op: qml.CoherentState, qc: bq.CVCircuit, regmapper: RegisterMapping):
+    r, phi = op.parameters
+    alpha = r * np.exp(1j * phi)
+    state = coherent_state(alpha, regmapper.truncation.dim(op.wires[0]))
+    qumode = regmapper.get(op.wires[0])
+    qc.cv_initialize(state, qumode)
+
+
+@apply_gate.register
+def _(op: qml.CatState, qc: bq.CVCircuit, regmapper: RegisterMapping):
+    a, phi, p = op.parameters
+    alpha = a * np.exp(1j * phi)
+    state_plus = coherent_state(alpha, regmapper.truncation.dim(op.wires[0]))
+    state_minus = coherent_state(-alpha, regmapper.truncation.dim(op.wires[0]))
+    norm = np.sqrt(2 * (1 + np.cos(p * np.pi) * np.exp(-2 * a**2)))
+    state = (state_plus + np.exp(1j * p * np.pi) * state_minus) / norm
+    qumode = regmapper.get(op.wires[0])
+    qc.cv_initialize(state, qumode)
+
+
+@apply_gate.register
+def _(op: qml.StatePrep, qc: bq.CVCircuit, regmapper: RegisterMapping):
+    state = op.parameters[0]
+
+    # StatePrep can allow for sparse statevectors
+    if sp.issparse(state):
+        state = state.todense()
+
+    # Flip the qubit order to match qiskit little endian convention instead of having to
+    # permute the statevector ourselves 🧠
+    qubits = [regmapper.get(w) for w in reversed(op.wires)]
+    qc.initialize(state, qubits=qubits)
+
+
+def pad_statevector_to_truncation(
+    state: np.ndarray, regmapper: RegisterMapping, wires: Wires
+) -> np.ndarray:
+    # The state has shape (n1, ..., nm) and we need to make sure each dimension matches
+    # the truncation for that wire
+    current_shape = state.shape
+    target_shape = regmapper.truncation.shape(wires)
+
+    # Check the right number of dimensions
+    if len(current_shape) != len(wires):
+        raise ValueError(
+            f"State has shape {current_shape} but expected {len(wires)} dimensions based on wires {wires}"
+        )
+
+    # If we potentially have a lossy conversion where we're putting our state in a lower
+    # dimensional space, just error
+    if any(ts < cs for ts, cs in zip(target_shape, current_shape)):
+        raise ValueError(
+            f"State shape {current_shape} exceeds truncation limits {target_shape} for wires {wires}"
+        )
+
+    # Now check that there's at least one mismatching dimension that we will pad with 0
+    if any(ts != cs for ts, cs in zip(target_shape, current_shape)):
+        pad_width = [(0, ts - cs) for ts, cs in zip(target_shape, current_shape)]
+        state = np.pad(state, pad_width, mode="constant", constant_values=0)
+
+    return state
 
 
 # todo: write unit tests for this function
@@ -518,3 +625,10 @@ def to_scalar(tensor_like: TensorLike):
 
     # Use .item() to extract the scalar value from a 0-dimensional NumPy array
     return np_array.item()
+
+
+def coherent_state(alpha: complex, cutoff: int) -> np.ndarray:
+    n = np.arange(cutoff)
+    state = alpha**n / np.sqrt(factorial(n))
+    norm = np.exp(-0.5 * np.abs(alpha) ** 2)
+    return norm * state

--- a/src/hybridlane/sa/infer_wires.py
+++ b/src/hybridlane/sa/infer_wires.py
@@ -151,6 +151,12 @@ def _(op: Controlled | ControlledOp | QubitConditioned):
     return wire_types
 
 
+@_infer_wire_types_from_operator.register
+def _(op: qml.BasisState | qml.StatePrep | qml.Superposition):
+    wire_types = {w: Qubit() for w in op.wires}
+    return wire_types
+
+
 def _infer_wire_types_from_measurement(
     m: MeasurementProcess,
 ) -> dict[WiresLike, WireType]:

--- a/test/devices/bosonic_qiskit/test_device.py
+++ b/test/devices/bosonic_qiskit/test_device.py
@@ -249,6 +249,18 @@ class TestOperations:
         stabilizer, _ = circuit()
         assert np.isclose(stabilizer, 1)
 
+    def test_qubit_basis_state(self):
+        dev = qml.device("bosonicqiskit.hybrid", max_fock_level=16)
+
+        @qml.qnode(dev)
+        def circuit():
+            qml.BasisState([1, 0, 0], wires=[0, 1, 2])
+            hqml.D(1, 1, wires=3)  # again dummy qumode
+            return hqml.expval(qml.Z(0))
+
+        expval = circuit()
+        assert np.isclose(expval, -1)
+
 
 @pytest.mark.skipif(missing_bosonic_qiskit, reason="Requires bosonic qiskit")
 class TestObservableMeasurements:

--- a/test/devices/bosonic_qiskit/test_device.py
+++ b/test/devices/bosonic_qiskit/test_device.py
@@ -104,6 +104,32 @@ class TestBosonicQiskitDevice:
         with pytest.raises(StaticAnalysisError):
             circuit()
 
+    def test_units(self):
+        alpha = 1.5
+        truncation = FockTruncation.all_fock_space([0], {0: 16})
+
+        def circuit(alpha):
+            qml.Displacement(alpha, 0, 0)
+            return hqml.expval(hqml.QuadX(0)), hqml.expval(hqml.QuadP(0))
+
+        units = "standard"
+        dev = qml.device("bosonicqiskit.hybrid", truncation=truncation, units=units)
+        qnode = qml.QNode(circuit, dev)
+        expval_x, expval_p = qnode(alpha)
+        expected_x = np.sqrt(2) * alpha
+        expected_p = 0
+        assert np.isclose(expval_x, expected_x)
+        assert np.isclose(expval_p, expected_p)
+
+        units = "wigner"
+        dev = qml.device("bosonicqiskit.hybrid", truncation=truncation, units=units)
+        qnode = qml.QNode(circuit, dev)
+        expval_x, expval_p = qnode(alpha)
+        expected_x = alpha
+        expected_p = 0
+        assert np.isclose(expval_x, expected_x)
+        assert np.isclose(expval_p, expected_p)
+
 
 # Integration circuit-level tests go in here
 @pytest.mark.skipif(missing_bosonic_qiskit, reason="Requires bosonic qiskit")
@@ -230,8 +256,8 @@ class TestExampleCircuits:
             return hqml.expval(hqml.QuadX(0)), hqml.expval(hqml.QuadP(0))
 
         expval_x, expval_p = circuit(alpha, phi)
-        expected_x = 2 * np.cos(phi) * alpha
-        expected_p = 2 * np.sin(phi) * alpha
+        expected_x = np.sqrt(2) * np.cos(phi) * alpha
+        expected_p = np.sqrt(2) * np.sin(phi) * alpha
         assert np.isclose(expval_x, expected_x)
         assert np.isclose(expval_p, expected_p)
 

--- a/test/devices/bosonic_qiskit/test_device.py
+++ b/test/devices/bosonic_qiskit/test_device.py
@@ -131,12 +131,129 @@ class TestBosonicQiskitDevice:
         assert np.isclose(expval_p, expected_p)
 
 
-# Integration circuit-level tests go in here
 @pytest.mark.skipif(missing_bosonic_qiskit, reason="Requires bosonic qiskit")
-class TestExampleCircuits:
+class TestOperations:
+    def test_fockstatevector(self):
+        dev = qml.device("bosonicqiskit.hybrid", max_fock_level=4)
+
+        # Put qumode 0 in state |2> and put qumode 1 in a superposition of |0> and |1>
+        state0 = np.zeros((4,), dtype=complex)
+        state0[2] = 1.0
+        state1 = np.zeros((4,), dtype=complex)
+        state1[0] = 1 / np.sqrt(2)
+        state1[1] = 1 / np.sqrt(2)
+        state = np.kron(state0, state1).reshape(4, 4)
+
+        @qml.qnode(dev)
+        def circuit():
+            qml.FockStateVector(state, wires=[0, 1])
+            return (hqml.expval(hqml.N(0)), hqml.expval(hqml.N(1)))
+
+        n0, n1 = circuit()
+        assert np.isclose(n0, 2)
+        assert np.isclose(n1, 0.5)
+
+    @pytest.mark.parametrize("alpha", (0.2, 0.5, 1.0, -1.0, -0.5, -0.2))
+    def test_displacement(self, alpha):
+        # Basic circuit that prepares |α> and checks the mean photon count
+        # is <n> = |α|^2
+        dev = qml.device("bosonicqiskit.hybrid", max_fock_level=16)
+
+        @qml.qnode(dev)
+        def circuit(alpha):
+            qml.Displacement(alpha, 0, 0)
+            return hqml.expval(hqml.NumberOperator(0)), hqml.var(hqml.NumberOperator(0))
+
+        expval, var = circuit(alpha)
+        assert np.ndim(expval) == 0
+        assert np.ndim(var) == 0
+        assert np.isclose(expval, np.abs(alpha) ** 2)
+        assert np.isclose(var, np.abs(alpha) ** 2)
+
+    def test_multiqumode_displacement(self):
+        alpha = 1
+        lam = np.abs(alpha) ** 2
+        truncation = FockTruncation.all_fock_space([0, 1], {0: 16, 1: 4})
+
+        dev = qml.device("bosonicqiskit.hybrid", truncation=truncation)
+
+        @qml.qnode(dev)
+        def circuit(alpha):
+            qml.Displacement(alpha, 0, 0)
+            return hqml.expval(hqml.NumberOperator(0)), hqml.expval(
+                hqml.NumberOperator(1)
+            )
+
+        n0, n1 = circuit(alpha)
+        assert np.isclose(n0, lam)
+        assert np.isclose(n1, 0)
+
+    @pytest.mark.parametrize("phi", (0, np.pi / 2, np.pi, 3 * np.pi / 2))
+    def test_rotation(self, phi):
+        alpha = 1.5
+        truncation = FockTruncation.all_fock_space([0], {0: 16})
+
+        dev = qml.device("bosonicqiskit.hybrid", truncation=truncation)
+
+        @qml.qnode(dev)
+        def circuit(alpha, phi):
+            qml.Displacement(alpha, 0, 0)
+            qml.Rotation(phi, 0)
+            return hqml.expval(hqml.QuadX(0)), hqml.expval(hqml.QuadP(0))
+
+        expval_x, expval_p = circuit(alpha, phi)
+        expected_x = np.sqrt(2) * np.cos(phi) * alpha
+        expected_p = np.sqrt(2) * np.sin(phi) * alpha
+        assert np.isclose(expval_x, expected_x)
+        assert np.isclose(expval_p, expected_p)
+
+    def test_coherent_state(self):
+        alpha = 1.5
+        dev = qml.device("bosonicqiskit.hybrid", max_fock_level=16)
+
+        @qml.qnode(dev)
+        def circuit(alpha):
+            qml.CoherentState(alpha, 0, wires=0)
+            return hqml.expval(hqml.N(0))
+
+        expval = circuit(alpha)
+        assert np.isclose(expval, np.abs(alpha) ** 2)
+
+    def test_cat_state(self):
+        alpha = 1.5
+        dev = qml.device("bosonicqiskit.hybrid", max_fock_level=16)
+
+        @qml.qnode(dev)
+        def circuit(alpha):
+            qml.CatState(alpha, 0, p=1, wires=0)
+            qml.change_op_basis(qml.H(1), hqml.CP([1, 0]))
+            return hqml.expval(qml.Z(1))
+
+        expval = circuit(alpha)
+        assert np.isclose(expval, -1)
+
+    def test_bell_state_prep(self):
+        dev = qml.device("bosonicqiskit.hybrid", max_fock_level=16)
+
+        state = np.zeros((4,), dtype=complex)
+        state[1] = 1 / np.sqrt(2)
+        state[2] = 1 / np.sqrt(2)
+
+        @qml.qnode(dev)
+        def circuit():
+            # Prepare a bell state and then measure a vacuum qumode just because
+            # bosonic qiskit requires 1 qumode
+            qml.StatePrep(state, wires=[0, 1])
+            return hqml.expval(qml.X(0) @ qml.X(1)), hqml.expval(hqml.N(2))
+
+        stabilizer, _ = circuit()
+        assert np.isclose(stabilizer, 1)
+
+
+@pytest.mark.skipif(missing_bosonic_qiskit, reason="Requires bosonic qiskit")
+class TestObservableMeasurements:
     def test_vacuum_expval(self):
         # The simplest test you could do, checking the vacuum state |0> has <n> = 0
-
         dev = qml.device("bosonicqiskit.hybrid", max_fock_level=16)
 
         @qml.qnode(dev)
@@ -160,55 +277,17 @@ class TestExampleCircuits:
         assert np.isclose(result, 0)
 
     def test_heisenberg_uncertainty(self):
-        dev = qml.device("bosonicqiskit.hybrid", max_fock_level=16, hbar=2)
+        dev = qml.device("bosonicqiskit.hybrid", max_fock_level=16)
 
         @qml.qnode(dev)
         def circuit():
             return hqml.var(hqml.QuadX(0)), hqml.var(hqml.QuadP(0))
 
-        hbar = 2
         dx, dp = circuit()
-        assert dx * dp >= hbar / 2
+        assert np.sqrt(dx * dp) >= 1 / 2
 
     @pytest.mark.parametrize("alpha", (0.2, 0.5, 1.0, -1.0, -0.5, -0.2))
-    def test_displacement_analytic(self, alpha):
-        # Basic circuit that prepares |α> and checks the mean photon count
-        # is <n> = |α|^2
-        dev = qml.device("bosonicqiskit.hybrid", max_fock_level=16)
-
-        @qml.qnode(dev)
-        def circuit(alpha):
-            qml.Displacement(alpha, 0, 0)
-            return hqml.expval(hqml.NumberOperator(0)), hqml.var(hqml.NumberOperator(0))
-
-        expval, var = circuit(alpha)
-        assert np.ndim(expval) == 0
-        assert np.ndim(var) == 0
-        assert np.isclose(expval, np.abs(alpha) ** 2)
-        assert np.isclose(var, np.abs(alpha) ** 2)
-
-    def test_displacement_on_multiqumode_system(self):
-        alpha = 1
-        lam = np.abs(alpha) ** 2
-        truncation = FockTruncation.all_fock_space([0, 1], {0: 16, 1: 4})
-
-        dev = qml.device("bosonicqiskit.hybrid", truncation=truncation)
-
-        @qml.qnode(dev)
-        def circuit(alpha):
-            qml.Displacement(alpha, 0, 0)
-            return hqml.expval(hqml.NumberOperator(0)), hqml.expval(
-                hqml.NumberOperator(1)
-            )
-
-        n0, n1 = circuit(alpha)
-        assert np.isclose(n0, lam)
-        assert np.isclose(n1, 0)
-
-    @pytest.mark.parametrize("alpha", (0.2, 0.5, 1.0, -1.0, -0.5, -0.2))
-    def test_displacement_sampled(self, alpha):
-        # Same test as above, but with finite samples. We'll test against the poisson distribution.
-        # This tests finite sampling of unbounded cv operators (HasSpectrum)
+    def test_sample_coherent_state(self, alpha):
         fock_levels = 16
         lam = np.abs(alpha) ** 2
         n_per_test = 5000
@@ -220,13 +299,11 @@ class TestExampleCircuits:
         @qml.qnode(dev)
         def circuit(alpha):
             qml.Displacement(alpha, 0, 0)
-            return hqml.expval(hqml.NumberOperator(0)), hqml.sample(
-                hqml.NumberOperator(0)
-            )
+            return hqml.sample(hqml.NumberOperator(0))
 
         # Rather than repeat the circuit `repetitions` times, which would be slower,
         # we just partition the shots ourselves into that many tests
-        expval, samples = circuit(alpha)
+        samples = circuit(alpha)
         sample_set = samples.reshape(repetitions, n_per_test)
 
         # Sample format test
@@ -241,71 +318,6 @@ class TestExampleCircuits:
 
         # Check that we didn't reject more than a majority of our tests
         assert rejections / repetitions < 0.5
-
-    @pytest.mark.parametrize("phi", (0, np.pi / 2, np.pi, 3 * np.pi / 2))
-    def test_rotation_analytic(self, phi):
-        alpha = 1.5
-        truncation = FockTruncation.all_fock_space([0], {0: 16})
-
-        dev = qml.device("bosonicqiskit.hybrid", truncation=truncation)
-
-        @qml.qnode(dev)
-        def circuit(alpha, phi):
-            qml.Displacement(alpha, 0, 0)
-            qml.Rotation(phi, 0)
-            return hqml.expval(hqml.QuadX(0)), hqml.expval(hqml.QuadP(0))
-
-        expval_x, expval_p = circuit(alpha, phi)
-        expected_x = np.sqrt(2) * np.cos(phi) * alpha
-        expected_p = np.sqrt(2) * np.sin(phi) * alpha
-        assert np.isclose(expval_x, expected_x)
-        assert np.isclose(expval_p, expected_p)
-
-    @pytest.mark.parametrize("n", range(6))
-    def test_create_fock_state_analytic(self, n):
-        # Creates the state |0,n> through JC gates
-        dev = qml.device("bosonicqiskit.hybrid", wires=[0, "m0"], max_fock_level=8)
-
-        @qml.qnode(dev)
-        def circuit():
-            for j in range(n):
-                qml.X(0)
-                hqml.JaynesCummings(np.pi / (2 * np.sqrt(j + 1)), np.pi / 2, [0, "m0"])
-
-            return hqml.expval(hqml.NumberOperator("m0")), hqml.expval(qml.Z(0))
-
-        expval_n, expval_z = circuit()
-        assert np.isclose(expval_n, n)
-        assert np.isclose(expval_z, 1.0)
-
-    def test_jc_analytic(self):
-        dev = qml.device("bosonicqiskit.hybrid", max_fock_level=4)
-
-        @qml.qnode(dev)
-        def circuit():
-            # Put the first subsystem (qubit 0, qumode 1) in state |0>_Q |1>_B
-            qml.X(0)
-            hqml.JaynesCummings(np.pi / 2, np.pi / 2, [0, 1])
-
-            # Put the second subsystem (qubit 2, qumode 3) in state |0>_Q |2>_B
-            qml.X(2)
-            hqml.JaynesCummings(np.pi / 2, np.pi / 2, [2, 3])
-            qml.X(2)
-            hqml.JaynesCummings(np.pi / (2 * np.sqrt(2)), np.pi / 2, [2, 3])
-
-            # check qumodes in state |1>|2>
-            return (
-                qml.expval(
-                    hqml.FockStateProjector([1, 2], [1, 3])
-                ),  # check that from_pennylane transform handles it
-                hqml.expval(hqml.NumberOperator(1)),
-                hqml.expval(hqml.NumberOperator(3)),
-            )
-
-        expval, n1, n3 = circuit()
-        assert np.isclose(n1, 1)
-        assert np.isclose(n3, 2)
-        assert np.isclose(expval, 1.0)
 
     def test_complex_fock_observable_analytic(self):
         # This is another coherent state, but this time we measure n + n^2, which
@@ -325,23 +337,6 @@ class TestExampleCircuits:
         expval_n = lam
         expval_n2 = lam + lam**2
         assert np.isclose(n, expval_n + expval_n2)
-
-    def test_cv_swap(self):
-        dev = qml.device("bosonicqiskit.hybrid", max_fock_level=16)
-
-        @qml.qnode(dev)
-        def circuit(alpha):
-            qml.Displacement(alpha, 0, 0)
-            hqml.ModeSwap([0, 1])  # will get decomposed to beamsplitters
-            qml.Displacement(-alpha, 0, 1)
-            return hqml.expval(hqml.NumberOperator(0)), hqml.expval(
-                hqml.NumberOperator(1)
-            )
-
-        alpha = 1.5
-        n1, n2 = circuit(alpha)
-        assert np.isclose(n1, 0)
-        assert np.isclose(n2, 0)
 
     # Fixme: this test fails because constructing ExpectationMP infers a schema, but
     # the schemas for n and x are different. However, technically in an analytic
@@ -366,28 +361,9 @@ class TestExampleCircuits:
         expval_x = 2 * alpha
         assert np.isclose(n, expval_n + expval_x)
 
-    @pytest.mark.parametrize("alpha", (2.0, -2.0))
-    def test_cat_state_readout(self, alpha):
-        dev = qml.device("bosonicqiskit.hybrid", max_fock_level=16)
 
-        @qml.qnode(dev)
-        def circuit(alpha):
-            # Put the qumode into state |α> + |-α>, which acts like |0L> + |1L>
-            qml.H(0)
-            hqml.CD(alpha, 0, wires=[0, 1])
-            qml.H(0)
-
-            # Now use ancilliary qubit to read it out with a phase kickback
-            qml.Displacement(alpha, 0, 1)  # |0> + |2α>
-            qml.H(2)
-            hqml.SQR(np.pi, np.pi / 2, 0, wires=[2, 1])  # Ry(pi)|0><0|
-            qml.H(2)
-
-            return hqml.expval(qml.Z(2))
-
-        z = circuit(alpha)
-        assert np.isclose(z, 0, atol=1e-7)
-
+@pytest.mark.skipif(missing_bosonic_qiskit, reason="Requires bosonic qiskit")
+class TestStateMeasurements:
     @pytest.mark.parametrize(["wires", "state_index"], [([0, 1], 1), ([1, 0], 2)])
     def test_statevector_with_wire_flips(self, wires, state_index):
         fock_levels = 4
@@ -448,3 +424,92 @@ class TestExampleCircuits:
         target = np.zeros((32,), dtype=complex)
         target[state_index] = 1.0
         assert np.allclose(state, target)
+
+
+# Integration circuit-level tests go in here
+@pytest.mark.skipif(missing_bosonic_qiskit, reason="Requires bosonic qiskit")
+class TestIntegration:
+    @pytest.mark.parametrize("n", range(6))
+    def test_create_fock_state_analytic(self, n):
+        # Creates the state |0,n> through JC gates
+        dev = qml.device("bosonicqiskit.hybrid", wires=[0, "m0"], max_fock_level=8)
+
+        @qml.qnode(dev)
+        def circuit():
+            for j in range(n):
+                qml.X(0)
+                hqml.JaynesCummings(np.pi / (2 * np.sqrt(j + 1)), np.pi / 2, [0, "m0"])
+
+            return hqml.expval(hqml.NumberOperator("m0")), hqml.expval(qml.Z(0))
+
+        expval_n, expval_z = circuit()
+        assert np.isclose(expval_n, n)
+        assert np.isclose(expval_z, 1.0)
+
+    def test_jc_analytic(self):
+        dev = qml.device("bosonicqiskit.hybrid", max_fock_level=4)
+
+        @qml.qnode(dev)
+        def circuit():
+            # Put the first subsystem (qubit 0, qumode 1) in state |0>_Q |1>_B
+            qml.X(0)
+            hqml.JaynesCummings(np.pi / 2, np.pi / 2, [0, 1])
+
+            # Put the second subsystem (qubit 2, qumode 3) in state |0>_Q |2>_B
+            qml.X(2)
+            hqml.JaynesCummings(np.pi / 2, np.pi / 2, [2, 3])
+            qml.X(2)
+            hqml.JaynesCummings(np.pi / (2 * np.sqrt(2)), np.pi / 2, [2, 3])
+
+            # check qumodes in state |1>|2>
+            return (
+                qml.expval(
+                    hqml.FockStateProjector([1, 2], [1, 3])
+                ),  # check that from_pennylane transform handles it
+                hqml.expval(hqml.NumberOperator(1)),
+                hqml.expval(hqml.NumberOperator(3)),
+            )
+
+        expval, n1, n3 = circuit()
+        assert np.isclose(n1, 1)
+        assert np.isclose(n3, 2)
+        assert np.isclose(expval, 1.0)
+
+    def test_cv_swap(self):
+        dev = qml.device("bosonicqiskit.hybrid", max_fock_level=16)
+
+        @qml.qnode(dev)
+        def circuit(alpha):
+            qml.Displacement(alpha, 0, 0)
+            hqml.ModeSwap([0, 1])  # will get decomposed to beamsplitters
+            qml.Displacement(-alpha, 0, 1)
+            return hqml.expval(hqml.NumberOperator(0)), hqml.expval(
+                hqml.NumberOperator(1)
+            )
+
+        alpha = 1.5
+        n1, n2 = circuit(alpha)
+        assert np.isclose(n1, 0)
+        assert np.isclose(n2, 0)
+
+    @pytest.mark.parametrize("alpha", (2.0, -2.0))
+    def test_cat_state_readout(self, alpha):
+        dev = qml.device("bosonicqiskit.hybrid", max_fock_level=16)
+
+        @qml.qnode(dev)
+        def circuit(alpha):
+            # Put the qumode into state |α> + |-α>, which acts like |0L> + |1L>
+            qml.H(0)
+            hqml.CD(alpha, 0, wires=[0, 1])
+            qml.H(0)
+
+            # Now use ancilliary qubit to read it out with a phase kickback
+            qml.Displacement(alpha, 0, 1)  # |0> + |2α>
+            qml.H(2)
+            hqml.SQR(np.pi, np.pi / 2, 0, wires=[2, 1])  # Ry(pi)|0><0|
+            qml.H(2)
+
+            return hqml.expval(qml.Z(2))
+
+        z = circuit(alpha)
+        assert np.isclose(z, 0, atol=1e-7)


### PR DESCRIPTION
It's a feature requested several times, so this adds support for a few of the PennyLane state preparation routines inside the `bosonicqiskit.hybrid` device:
- `qml.StatePrep`: Arbitrary state preparation on qubits
- `qml.CoherentState`: Prepares a coherent state on a single qumode
- `qml.CatState`: Prepares a cat state on a single qumode
- `qml.FockStateVector`: Allows preparing an arbitrary CV state on qumodes in the Fock basis

This also sets the default value of $\hbar = 1$ in the device to match the convention of the ISA paper, then a flag to control standard (default) versus Wigner units is also introduced.