### PR TITLE
Use test markers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,4 +15,4 @@ repos:
     - repo: https://codeberg.org/fsfe/reuse-tool
       rev: v6.2.0
       hooks:
-          - id: reuse
+          - id: reuse-lint-file

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Battelle Memorial Institute
 # SPDX-License-Identifier: BSD-2-Clause
 # Based on Sybil documentation: https://sybil.readthedocs.io/en/latest/quickstart.html
+import importlib.util
 from doctest import ELLIPSIS
 from typing import Any
 
@@ -20,11 +21,13 @@ def setup(namespace: dict[str, Any]):
     }
 
 
-pytest_collect_file = Sybil(
-    parsers=[
-        DocTestParser(optionflags=ELLIPSIS),
-        PythonCodeBlockParser(),
-    ],
-    patterns=["docs/source/*.rst", "*.py"],
-    setup=setup,
-).pytest()
+# todo: rework doc testing to skip tests involving bosonic qiskit if it's not installed
+if importlib.util.find_spec("bosonic_qiskit") is not None:
+    pytest_collect_file = Sybil(
+        parsers=[
+            DocTestParser(optionflags=ELLIPSIS),
+            PythonCodeBlockParser(),
+        ],
+        patterns=["docs/source/*.rst", "*.py"],
+        setup=setup,
+    ).pytest()

--- a/pytest.toml
+++ b/pytest.toml
@@ -5,6 +5,7 @@ markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "unit: marks tests as unit tests (select with '-m \"unit\"')",
     "integration: marks tests as integration tests (select with '-m \"integration\"')",
+    "bq: marks tests that use Bosonic Qiskit (select with '-m \"bq\"')",
     "torch: marks tests that use PyTorch (select with '-m \"torch\"')",
     "jax: marks tests that use JAX (select with '-m \"jax\"')",
 ]

--- a/pytest.toml
+++ b/pytest.toml
@@ -3,4 +3,8 @@
 [pytest]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "unit: marks tests as unit tests (select with '-m \"unit\"')",
+    "integration: marks tests as integration tests (select with '-m \"integration\"')",
+    "torch: marks tests that use PyTorch (select with '-m \"torch\"')",
+    "jax: marks tests that use JAX (select with '-m \"jax\"')",
 ]

--- a/src/hybridlane/drawer/tape_mpl.py
+++ b/src/hybridlane/drawer/tape_mpl.py
@@ -17,13 +17,15 @@ from pennylane.drawer.utils import (
 from pennylane.tape import QuantumScript
 
 from .. import ops, sa
-from .mpldrawer import HybridMPLDrawer
 
 has_mpl = True
 try:
     import matplotlib as mpl
+
+    from .mpldrawer import HybridMPLDrawer
 except (ModuleNotFoundError, ImportError):
     has_mpl = False
+    HybridMPLDrawer = object
 
 default_qumode_color = "mediumseagreen"
 default_qubit_color = "darkorchid"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Battelle Memorial Institute
 # SPDX-License-Identifier: BSD-2-Clause
+import importlib.util
+
 import pennylane as qp
 import pytest
 
@@ -16,3 +18,23 @@ def disable_graph_decomp():
     qp.decomposition.disable_graph()
     yield
     qp.decomposition.enable_graph()
+
+
+def pytest_collection_modifyitems(config, items):
+    if importlib.util.find_spec("jax") is None:
+        skip_jax = pytest.mark.skip(reason="jax not installed")
+        for item in items:
+            if "jax" in item.keywords:
+                item.add_marker(skip_jax)
+
+    if importlib.util.find_spec("torch") is None:
+        skip_torch = pytest.mark.skip(reason="torch not installed")
+        for item in items:
+            if "torch" in item.keywords:
+                item.add_marker(skip_torch)
+
+    if importlib.util.find_spec("bosonic_qiskit") is None:
+        skip_bq = pytest.mark.skip(reason="bosonic_qiskit not installed")
+        for item in items:
+            if "bq" in item.keywords:
+                item.add_marker(skip_bq)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2025 Battelle Memorial Institute
+# SPDX-License-Identifier: BSD-2-Clause
+import pennylane as qp
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def enable_graph_decomp():
+    qp.decomposition.enable_graph()
+    yield
+    qp.decomposition.disable_graph()
+
+
+@pytest.fixture(autouse=True)
+def disable_graph_decomp():
+    qp.decomposition.disable_graph()
+    yield
+    qp.decomposition.enable_graph()

--- a/test/decomposition/test_graph_decomposition.py
+++ b/test/decomposition/test_graph_decomposition.py
@@ -44,6 +44,7 @@ qml.add_decomps("Pow(Evo)", pow_rotation)
 
 @pytest.mark.usefixtures("enable_graph_decomp")
 class TestApplications:
+    @pytest.mark.bq
     @pytest.mark.integration
     def test_dispersive_qpe(self):
         omega_r = 1
@@ -90,6 +91,7 @@ class TestApplications:
 @pytest.mark.usefixtures("enable_graph_decomp")
 class TestGateDecompositions:
     @pytest.mark.integration
+    @pytest.mark.bq
     def test_snap_to_sqr(self):
         dev = qml.device("bosonicqiskit.hybrid", max_fock_level=32)
 

--- a/test/decomposition/test_graph_decomposition.py
+++ b/test/decomposition/test_graph_decomposition.py
@@ -15,13 +15,6 @@ from hybridlane.ops.mixins import Hybrid
 from hybridlane.sa import BasisSchema, ComputationalBasis
 
 
-@pytest.fixture(scope="class", autouse=True)
-def graph_enabled():
-    qml.decomposition.enable_graph()
-    yield
-    qml.decomposition.disable_graph()
-
-
 # Necessary to define this class so we can give the pow_rotation decomposition. Otherwise,
 # pennylane uses the pow_repeat_base decomposition and that dramatically expands the circuit depth
 class Evo(Operation, Hybrid):
@@ -49,7 +42,9 @@ qml.add_decomps(Evo, _evo_decomp)
 qml.add_decomps("Pow(Evo)", pow_rotation)
 
 
+@pytest.mark.usefixtures("enable_graph_decomp")
 class TestApplications:
+    @pytest.mark.integration
     def test_dispersive_qpe(self):
         omega_r = 1
         omega_q = -1
@@ -92,7 +87,9 @@ class TestApplications:
         assert gate_types["Rotation"] == 5  # 1 per R term
 
 
+@pytest.mark.usefixtures("enable_graph_decomp")
 class TestGateDecompositions:
+    @pytest.mark.integration
     def test_snap_to_sqr(self):
         dev = qml.device("bosonicqiskit.hybrid", max_fock_level=32)
 

--- a/test/devices/bosonic_qiskit/test_device.py
+++ b/test/devices/bosonic_qiskit/test_device.py
@@ -16,6 +16,7 @@ from hybridlane.sa.exceptions import StaticAnalysisError
 from ...util import poisson_test
 
 
+@pytest.mark.unit
 def test_package_works_without_bosonic_qiskit(monkeypatch):
     monkeypatch.delitem(sys.modules, "bosonic_qiskit", raising=False)
     import hybridlane  # noqa: F401
@@ -24,15 +25,16 @@ def test_package_works_without_bosonic_qiskit(monkeypatch):
 missing_bosonic_qiskit = importlib.util.find_spec("bosonic_qiskit") is None
 
 
-# Unit tests should go in here
 @pytest.mark.skipif(missing_bosonic_qiskit, reason="Requires bosonic qiskit")
 class TestBosonicQiskitDevice:
+    @pytest.mark.unit
     def test_device_is_registered(self):
         from hybridlane.devices import BosonicQiskitDevice
 
         dev = qml.device("bosonicqiskit.hybrid")
         assert isinstance(dev, BosonicQiskitDevice)
 
+    @pytest.mark.unit
     def test_non_power_of_two_truncation(self):
         trunc = FockTruncation.all_fock_space([0, 1], {0: 2, 1: 7})
         dev = qml.device("bosonicqiskit.hybrid", truncation=trunc)
@@ -45,6 +47,7 @@ class TestBosonicQiskitDevice:
         with pytest.raises(DeviceError):
             circuit()
 
+    @pytest.mark.unit
     def test_no_inferrable_truncation(self):
         # This circuit has a qumode that should be detected through static analysis,
         # but no truncation is provided.
@@ -58,6 +61,7 @@ class TestBosonicQiskitDevice:
         with pytest.raises(DeviceError):
             circuit()
 
+    @pytest.mark.unit
     def test_infer_qubits(self):
         # This circuit should be detected as all qubit and therefore automagically
         # derive a truncation of 2 for each qubit. It'll then fail because
@@ -72,6 +76,7 @@ class TestBosonicQiskitDevice:
         with pytest.raises(DeviceError):
             circuit()
 
+    @pytest.mark.unit
     def test_wires_aliased_by_operation(self):
         dev = qml.device("bosonicqiskit.hybrid", max_fock_level=8)
 
@@ -85,6 +90,7 @@ class TestBosonicQiskitDevice:
         with pytest.raises(StaticAnalysisError):
             circuit()
 
+    @pytest.mark.unit
     @pytest.mark.parametrize(
         "obs",
         (
@@ -104,6 +110,7 @@ class TestBosonicQiskitDevice:
         with pytest.raises(StaticAnalysisError):
             circuit()
 
+    @pytest.mark.integration
     def test_units(self):
         alpha = 1.5
         truncation = FockTruncation.all_fock_space([0], {0: 16})
@@ -133,6 +140,7 @@ class TestBosonicQiskitDevice:
 
 @pytest.mark.skipif(missing_bosonic_qiskit, reason="Requires bosonic qiskit")
 class TestOperations:
+    @pytest.mark.integration
     def test_fockstatevector(self):
         dev = qml.device("bosonicqiskit.hybrid", max_fock_level=4)
 
@@ -153,6 +161,7 @@ class TestOperations:
         assert np.isclose(n0, 2)
         assert np.isclose(n1, 0.5)
 
+    @pytest.mark.integration
     @pytest.mark.parametrize("alpha", (0.2, 0.5, 1.0, -1.0, -0.5, -0.2))
     def test_displacement(self, alpha):
         # Basic circuit that prepares |α> and checks the mean photon count
@@ -170,6 +179,7 @@ class TestOperations:
         assert np.isclose(expval, np.abs(alpha) ** 2)
         assert np.isclose(var, np.abs(alpha) ** 2)
 
+    @pytest.mark.integration
     def test_multiqumode_displacement(self):
         alpha = 1
         lam = np.abs(alpha) ** 2
@@ -188,6 +198,7 @@ class TestOperations:
         assert np.isclose(n0, lam)
         assert np.isclose(n1, 0)
 
+    @pytest.mark.integration
     @pytest.mark.parametrize("phi", (0, np.pi / 2, np.pi, 3 * np.pi / 2))
     def test_rotation(self, phi):
         alpha = 1.5
@@ -207,6 +218,7 @@ class TestOperations:
         assert np.isclose(expval_x, expected_x)
         assert np.isclose(expval_p, expected_p)
 
+    @pytest.mark.integration
     def test_coherent_state(self):
         alpha = 1.5
         dev = qml.device("bosonicqiskit.hybrid", max_fock_level=16)
@@ -219,6 +231,7 @@ class TestOperations:
         expval = circuit(alpha)
         assert np.isclose(expval, np.abs(alpha) ** 2)
 
+    @pytest.mark.integration
     def test_cat_state(self):
         alpha = 1.5
         dev = qml.device("bosonicqiskit.hybrid", max_fock_level=16)
@@ -232,6 +245,7 @@ class TestOperations:
         expval = circuit(alpha)
         assert np.isclose(expval, -1)
 
+    @pytest.mark.integration
     def test_bell_state_prep(self):
         dev = qml.device("bosonicqiskit.hybrid", max_fock_level=16)
 
@@ -249,6 +263,7 @@ class TestOperations:
         stabilizer, _ = circuit()
         assert np.isclose(stabilizer, 1)
 
+    @pytest.mark.integration
     def test_qubit_basis_state(self):
         dev = qml.device("bosonicqiskit.hybrid", max_fock_level=16)
 
@@ -264,6 +279,7 @@ class TestOperations:
 
 @pytest.mark.skipif(missing_bosonic_qiskit, reason="Requires bosonic qiskit")
 class TestObservableMeasurements:
+    @pytest.mark.integration
     def test_vacuum_expval(self):
         # The simplest test you could do, checking the vacuum state |0> has <n> = 0
         dev = qml.device("bosonicqiskit.hybrid", max_fock_level=16)
@@ -276,6 +292,7 @@ class TestObservableMeasurements:
         assert np.ndim(result) == 0
         assert np.isclose(result, 0)
 
+    @pytest.mark.integration
     def test_vacuum_var(self):
         # Checking the vacuum state |0> has Var(n) = 0 since it's a definite eigenstate
         dev = qml.device("bosonicqiskit.hybrid", max_fock_level=16)
@@ -288,6 +305,7 @@ class TestObservableMeasurements:
         assert np.ndim(result) == 0
         assert np.isclose(result, 0)
 
+    @pytest.mark.integration
     def test_heisenberg_uncertainty(self):
         dev = qml.device("bosonicqiskit.hybrid", max_fock_level=16)
 
@@ -298,6 +316,7 @@ class TestObservableMeasurements:
         dx, dp = circuit()
         assert np.sqrt(dx * dp) >= 1 / 2
 
+    @pytest.mark.integration
     @pytest.mark.parametrize("alpha", (0.2, 0.5, 1.0, -1.0, -0.5, -0.2))
     def test_sample_coherent_state(self, alpha):
         fock_levels = 16
@@ -331,6 +350,7 @@ class TestObservableMeasurements:
         # Check that we didn't reject more than a majority of our tests
         assert rejections / repetitions < 0.5
 
+    @pytest.mark.integration
     def test_complex_fock_observable_analytic(self):
         # This is another coherent state, but this time we measure n + n^2, which
         # is diagonal in fock basis. However, this tests some of the static analysis
@@ -354,6 +374,7 @@ class TestObservableMeasurements:
     # the schemas for n and x are different. However, technically in an analytic
     # simulation of bosonic qiskit, it could handle this just fine. Maybe we need to be
     # more deliberate about where verification and static analysis happen?
+    @pytest.mark.integration
     @pytest.mark.xfail
     def test_complex_multibasis_observable_analytic(self):
         # This is another coherent state, but this time we measure n + x
@@ -376,6 +397,7 @@ class TestObservableMeasurements:
 
 @pytest.mark.skipif(missing_bosonic_qiskit, reason="Requires bosonic qiskit")
 class TestStateMeasurements:
+    @pytest.mark.integration
     @pytest.mark.parametrize(["wires", "state_index"], [([0, 1], 1), ([1, 0], 2)])
     def test_statevector_with_wire_flips(self, wires, state_index):
         fock_levels = 4
@@ -397,6 +419,7 @@ class TestStateMeasurements:
         target[state_index] = 1.0
         assert np.allclose(state, target)
 
+    @pytest.mark.integration
     @pytest.mark.parametrize(
         ["wires", "state_index"],
         [
@@ -438,7 +461,8 @@ class TestStateMeasurements:
         assert np.allclose(state, target)
 
 
-# Integration circuit-level tests go in here
+@pytest.mark.slow
+@pytest.mark.integration
 @pytest.mark.skipif(missing_bosonic_qiskit, reason="Requires bosonic qiskit")
 class TestIntegration:
     @pytest.mark.parametrize("n", range(6))

--- a/test/devices/bosonic_qiskit/test_device.py
+++ b/test/devices/bosonic_qiskit/test_device.py
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: 2025 Battelle Memorial Institute
 # SPDX-License-Identifier: BSD-2-Clause
-import importlib.util
 import sys
 from functools import partial
 
@@ -22,10 +21,7 @@ def test_package_works_without_bosonic_qiskit(monkeypatch):
     import hybridlane  # noqa: F401
 
 
-missing_bosonic_qiskit = importlib.util.find_spec("bosonic_qiskit") is None
-
-
-@pytest.mark.skipif(missing_bosonic_qiskit, reason="Requires bosonic qiskit")
+@pytest.mark.bq
 class TestBosonicQiskitDevice:
     @pytest.mark.unit
     def test_device_is_registered(self):
@@ -138,7 +134,7 @@ class TestBosonicQiskitDevice:
         assert np.isclose(expval_p, expected_p)
 
 
-@pytest.mark.skipif(missing_bosonic_qiskit, reason="Requires bosonic qiskit")
+@pytest.mark.bq
 class TestOperations:
     @pytest.mark.integration
     def test_fockstatevector(self):
@@ -277,7 +273,7 @@ class TestOperations:
         assert np.isclose(expval, -1)
 
 
-@pytest.mark.skipif(missing_bosonic_qiskit, reason="Requires bosonic qiskit")
+@pytest.mark.bq
 class TestObservableMeasurements:
     @pytest.mark.integration
     def test_vacuum_expval(self):
@@ -395,7 +391,7 @@ class TestObservableMeasurements:
         assert np.isclose(n, expval_n + expval_x)
 
 
-@pytest.mark.skipif(missing_bosonic_qiskit, reason="Requires bosonic qiskit")
+@pytest.mark.bq
 class TestStateMeasurements:
     @pytest.mark.integration
     @pytest.mark.parametrize(["wires", "state_index"], [([0, 1], 1), ([1, 0], 2)])
@@ -463,7 +459,7 @@ class TestStateMeasurements:
 
 @pytest.mark.slow
 @pytest.mark.integration
-@pytest.mark.skipif(missing_bosonic_qiskit, reason="Requires bosonic qiskit")
+@pytest.mark.bq
 class TestIntegration:
     @pytest.mark.parametrize("n", range(6))
     def test_create_fock_state_analytic(self, n):

--- a/test/devices/sandia_qscout/test_device.py
+++ b/test/devices/sandia_qscout/test_device.py
@@ -18,13 +18,7 @@ from hybridlane.devices.sandia_qscout import Qumode
 from hybridlane.devices.sandia_qscout import ops as ion
 
 
-@pytest.fixture(scope="class", autouse=True)
-def graph_enabled():
-    qml.decomposition.enable_graph()
-    yield
-    qml.decomposition.disable_graph()
-
-
+@pytest.mark.unit
 def test_package_works_without_jaqalpaq(monkeypatch):
     monkeypatch.delitem(sys.modules, "jaqalpaq", raising=False)
     monkeypatch.delitem(sys.modules, "qscout", raising=False)
@@ -35,8 +29,10 @@ def test_package_works_without_jaqalpaq(monkeypatch):
 missing_jaqalpaq = importlib.util.find_spec("jaqalpaq") is None
 
 
+@pytest.mark.usefixtures("enable_graph_decomp")
 @pytest.mark.skipif(missing_jaqalpaq, reason="jaqalpaq is not installed")
 class TestDevice:
+    @pytest.mark.unit
     @pytest.mark.parametrize("allow_com", (True, False))
     def test_com_modes(self, allow_com):
         dev = qml.device(
@@ -53,6 +49,7 @@ class TestDevice:
 
         assert len(dev.wires) == qubits + qumodes
 
+    @pytest.mark.integration
     @pytest.mark.parametrize(
         "obs",
         (
@@ -72,6 +69,7 @@ class TestDevice:
 
         circuit(obs)
 
+    @pytest.mark.integration
     @pytest.mark.parametrize(
         "obs",
         (
@@ -91,6 +89,7 @@ class TestDevice:
         with pytest.raises(DeviceError):
             circuit(obs)
 
+    @pytest.mark.integration
     @pytest.mark.parametrize(
         "wires, allowed",
         (
@@ -116,6 +115,7 @@ class TestDevice:
             with pytest.raises(DeviceError):
                 circuit(wires)
 
+    @pytest.mark.integration
     @pytest.mark.parametrize(
         "wires, allowed",
         (
@@ -142,6 +142,7 @@ class TestDevice:
             with pytest.raises(DeviceError):
                 circuit(wires)
 
+    @pytest.mark.unit
     def too_many_qubits(self):
         dev = qml.device("sandiaqscout.hybrid")
 
@@ -155,6 +156,7 @@ class TestDevice:
         with pytest.raises(DeviceError):
             circuit()
 
+    @pytest.mark.unit
     def too_many_qumodes(self):
         dev = qml.device("sandiaqscout.hybrid")
 
@@ -169,8 +171,10 @@ class TestDevice:
             circuit()
 
 
+@pytest.mark.usefixtures("enable_graph_decomp")
 @pytest.mark.skipif(missing_jaqalpaq, reason="jaqalpaq is not installed")
 class TestLayout:
+    @pytest.mark.integration
     def test_qumode_assignment(self):
         dev = qml.device("sandiaqscout.hybrid", n_qubits=4, use_virtual_wires=True)
 
@@ -187,6 +191,7 @@ class TestLayout:
         allowed_wires = Wires([Qumode(m, i) for m in (0, 1) for i in range(1, 4)])
         assert allowed_wires.contains_wires(sa_res.qumodes)
 
+    @pytest.mark.integration
     def test_qumode_assignment_with_com(self):
         dev = qml.device("sandiaqscout.hybrid", n_qubits=3, enable_com_modes=True)
 
@@ -203,6 +208,7 @@ class TestLayout:
         allowed_wires = Wires([Qumode(m, i) for m in (0, 1) for i in range(0, 4)])
         assert allowed_wires.contains_wires(sa_res.qumodes)
 
+    @pytest.mark.integration
     def test_no_valid_assignment(self):
         dev = qml.device("sandiaqscout.hybrid", n_qubits=3, enable_com_modes=True)
 
@@ -217,6 +223,8 @@ class TestLayout:
             construct_tape(circuit, level="device")()
 
 
+@pytest.mark.usefixtures("enable_graph_decomp")
+@pytest.mark.integration
 @pytest.mark.skipif(missing_jaqalpaq, reason="jaqalpaq is not installed")
 class TestDecomposition:
     def test_fockstate_and_conditionaldisplacement(self):

--- a/test/devices/sandia_qscout/test_jaqal.py
+++ b/test/devices/sandia_qscout/test_jaqal.py
@@ -23,13 +23,6 @@ from hybridlane.devices.sandia_qscout.jaqal import (  # noqa: E402
 )
 
 
-@pytest.fixture(scope="class", autouse=True)
-def graph_enabled():
-    qml.decomposition.enable_graph()
-    yield
-    qml.decomposition.disable_graph()
-
-
 def programs_equal(actual_ir, expected_ir):
     # Fake the qubit pulses as these are only valid on the emulator, not hardware
     import_statement = "from qscout.v1.std usepulses *\n"
@@ -57,6 +50,8 @@ def programs_equal(actual_ir, expected_ir):
         return actual_program == expected_program
 
 
+@pytest.mark.integration
+@pytest.mark.usefixtures("enable_graph_decomp")
 class TestToJaqal:
     def test_sample_qubit_circuit(self):
         dev = qml.device("sandiaqscout.hybrid")

--- a/test/devices/test_preprocess.py
+++ b/test/devices/test_preprocess.py
@@ -9,6 +9,7 @@ from hybridlane.devices import preprocess
 from hybridlane.sa.exceptions import StaticAnalysisError
 
 
+@pytest.mark.unit
 class TestValidateWireTypes:
     def test_bad_circuit(self):
         with qml.queuing.AnnotatedQueue() as q:

--- a/test/draw/test_draw_mpl.py
+++ b/test/draw/test_draw_mpl.py
@@ -29,6 +29,7 @@ def circuit1(n):
     return hqml.expval(hqml.NumberOperator(n))
 
 
+@pytest.mark.unit
 class TestIconBehavior:
     def test_icon_colors(self):
         icon_colors = {

--- a/test/draw/test_draw_mpl.py
+++ b/test/draw/test_draw_mpl.py
@@ -15,20 +15,24 @@ from hybridlane.drawer.tape_mpl import (  # noqa: E402
     default_qumode_color,
 )
 
-dev = qml.device("bosonicqiskit.hybrid", max_fock_level=8)
+
+def get_circuit1():
+    dev = qml.device("bosonicqiskit.hybrid", max_fock_level=8)
+
+    @qml.qnode(dev)
+    def circuit1(n):
+        qml.H(0)
+        hqml.Rotation(0.5, 1)
+
+        for i in range(n):
+            hqml.ConditionalDisplacement(0.5, 0, [0, 2 + i])
+
+        return hqml.expval(hqml.NumberOperator(n))
+
+    return circuit1
 
 
-@qml.qnode(dev)
-def circuit1(n):
-    qml.H(0)
-    hqml.Rotation(0.5, 1)
-
-    for i in range(n):
-        hqml.ConditionalDisplacement(0.5, 0, [0, 2 + i])
-
-    return hqml.expval(hqml.NumberOperator(n))
-
-
+@pytest.mark.bq
 @pytest.mark.unit
 class TestIconBehavior:
     def test_icon_colors(self):
@@ -40,6 +44,7 @@ class TestIconBehavior:
             6: "turquoise",
         }
 
+        circuit1 = get_circuit1()
         fig, ax = hqml.draw_mpl(
             circuit1,
             wire_icon_colors=icon_colors,

--- a/test/io/test_openqasm.py
+++ b/test/io/test_openqasm.py
@@ -15,6 +15,7 @@ def evaluate_openqasm_compliance(s: str):
     parse(s)  # errors if there's syntax mistake
 
 
+@pytest.mark.bq
 @pytest.mark.integration
 class TestCircuits:
     @pytest.mark.parametrize("strict", (True, False))

--- a/test/io/test_openqasm.py
+++ b/test/io/test_openqasm.py
@@ -15,6 +15,7 @@ def evaluate_openqasm_compliance(s: str):
     parse(s)  # errors if there's syntax mistake
 
 
+@pytest.mark.integration
 class TestCircuits:
     @pytest.mark.parametrize("strict", (True, False))
     def test_with_nondiagonal_measurement(self, strict):

--- a/test/measurements/test_measurement.py
+++ b/test/measurements/test_measurement.py
@@ -12,6 +12,7 @@ from hybridlane.measurements import (
 from hybridlane.sa.base import BasisSchema, ComputationalBasis
 
 
+@pytest.mark.unit
 class TestBasisSchema:
     def test_init(self):
         wire_map = {
@@ -47,6 +48,7 @@ class TestBasisSchema:
         assert schema1 != schema2
 
 
+@pytest.mark.unit
 class TestSampleResult:
     def test_init_basis_states(self):
         basis_states = {"a": np.array([1, 0]), "b": np.array([0, 1])}
@@ -75,6 +77,7 @@ class TestSampleResult:
         assert result3.shots == 2
 
 
+@pytest.mark.unit
 class TestCountsResult:
     def test_init_basis_states(self):
         counts = {(0, 1): 10, (1, 0): 20}
@@ -95,6 +98,7 @@ class TestCountsResult:
         assert result.shots == 40
 
 
+@pytest.mark.unit
 class TestFockTruncation:
     def test_shape(self):
         schema = BasisSchema(

--- a/test/measurements/test_sample.py
+++ b/test/measurements/test_sample.py
@@ -16,6 +16,7 @@ from hybridlane.ops import NumberOperator, QuadX
 from hybridlane.sa.base import BasisSchema, ComputationalBasis
 
 
+@pytest.mark.unit
 class TestSampleMP:
     """Unit tests for the SampleMP class."""
 

--- a/test/ops/op_math/test_qubit_conditioned.py
+++ b/test/ops/op_math/test_qubit_conditioned.py
@@ -9,13 +9,7 @@ import hybridlane as hqml
 from hybridlane.ops import QubitConditioned
 
 
-@pytest.fixture(scope="class")
-def graph_enabled():
-    qml.decomposition.enable_graph()
-    yield
-    qml.decomposition.disable_graph()
-
-
+@pytest.mark.unit
 class TestQubitConditioned:
     def test_name(self):
         op = QubitConditioned(hqml.Rotation(0.5, 0), 1)
@@ -59,6 +53,7 @@ class TestQubitConditioned:
         ]
 
 
+@pytest.mark.unit
 class TestDecomposition:
     def test_rz_to_isingzz(self):
         op = QubitConditioned(qml.RZ(0.5, 0), 1)
@@ -100,8 +95,10 @@ class TestDecomposition:
         ]
 
 
+@pytest.mark.usefixtures("enable_graph_decomp")
+@pytest.mark.integration
 class TestGraphDecomposition:
-    def test_qcondf_to_cr(self, graph_enabled):
+    def test_qcondf_to_cr(self):
         dev = qml.device("bosonicqiskit.hybrid", max_fock_level=8)
 
         @partial(
@@ -115,7 +112,7 @@ class TestGraphDecomposition:
         tape = qml.workflow.construct_tape(circuit)()
         assert len(tape.operations) == 1  # 1 cr
 
-    def test_multi_qcondf_to_cr(self, graph_enabled):
+    def test_multi_qcondf_to_cr(self):
         dev = qml.device("bosonicqiskit.hybrid", max_fock_level=8)
 
         @partial(
@@ -129,7 +126,7 @@ class TestGraphDecomposition:
         tape = qml.workflow.construct_tape(circuit)()
         assert len(tape.operations) == 3  # 1 cr, 2 cnot
 
-    def test_ctrlf_to_cr(self, graph_enabled):
+    def test_ctrlf_to_cr(self):
         dev = qml.device("bosonicqiskit.hybrid", max_fock_level=8)
 
         @partial(
@@ -143,7 +140,7 @@ class TestGraphDecomposition:
         tape = qml.workflow.construct_tape(circuit)()
         assert len(tape.operations) == 2  # 1 r, 1 cr
 
-    def test_multicondf_to_cr(self, graph_enabled):
+    def test_multicondf_to_cr(self):
         dev = qml.device("bosonicqiskit.hybrid", max_fock_level=8)
 
         @partial(
@@ -161,7 +158,7 @@ class TestGraphDecomposition:
             qml.CNOT([1, 2]),
         ]
 
-    def test_condbs_to_cbs(self, graph_enabled):
+    def test_condbs_to_cbs(self):
         dev = qml.device("bosonicqiskit.hybrid", max_fock_level=8)
 
         @partial(
@@ -175,7 +172,7 @@ class TestGraphDecomposition:
         tape = qml.workflow.construct_tape(circuit)()
         assert tape.operations == [hqml.ConditionalBeamsplitter(0.5, 0, [2, 0, 1])]
 
-    def test_multicondbs_to_cbs(self, graph_enabled):
+    def test_multicondbs_to_cbs(self):
         dev = qml.device("bosonicqiskit.hybrid", max_fock_level=8)
 
         @partial(
@@ -193,7 +190,7 @@ class TestGraphDecomposition:
             qml.CNOT([2, 3]),
         ]
 
-    def test_cond_cd(self, graph_enabled):
+    def test_cond_cd(self):
         dev = qml.device("bosonicqiskit.hybrid", max_fock_level=8)
 
         @partial(
@@ -213,7 +210,7 @@ class TestGraphDecomposition:
             qml.CNOT([2, 3]),
         ]
 
-    def test_cond_pow_cr(self, graph_enabled):
+    def test_cond_pow_cr(self):
         dev = qml.device("bosonicqiskit.hybrid", max_fock_level=8)
 
         @partial(
@@ -233,7 +230,7 @@ class TestGraphDecomposition:
             qml.CNOT([2, 3]),
         ]
 
-    def test_pow_adj_cr(self, graph_enabled):
+    def test_pow_adj_cr(self):
         dev = qml.device("bosonicqiskit.hybrid", max_fock_level=8)
 
         @partial(
@@ -247,7 +244,7 @@ class TestGraphDecomposition:
         tape = qml.workflow.construct_tape(circuit)()
         assert tape.operations == [hqml.ConditionalRotation(-2.5, [0, 1])]
 
-    def test_pow_cond_cr(self, graph_enabled):
+    def test_pow_cond_cr(self):
         dev = qml.device("bosonicqiskit.hybrid", max_fock_level=8)
 
         @partial(

--- a/test/ops/op_math/test_qubit_conditioned.py
+++ b/test/ops/op_math/test_qubit_conditioned.py
@@ -95,6 +95,8 @@ class TestDecomposition:
         ]
 
 
+# Todo: We should in principle be able to rewrite these to not use bosonic qiskit
+@pytest.mark.bq
 @pytest.mark.usefixtures("enable_graph_decomp")
 @pytest.mark.integration
 class TestGraphDecomposition:

--- a/test/ops/test_cv.py
+++ b/test/ops/test_cv.py
@@ -1,11 +1,13 @@
 # SPDX-FileCopyrightText: 2025 Battelle Memorial Institute
 # SPDX-License-Identifier: BSD-2-Clause
 import pennylane as qml
+import pytest
 from pennylane import numpy as np
 
 import hybridlane as hqml
 
 
+@pytest.mark.unit
 class TestTwoModeSum:
     def test_init(self):
         """Test the __init__ method."""
@@ -41,6 +43,7 @@ class TestTwoModeSum:
         assert isinstance(simplified_op, qml.Identity)
 
 
+@pytest.mark.unit
 class TestModeSwap:
     def test_init(self):
         """Test the __init__ method."""
@@ -76,6 +79,7 @@ class TestModeSwap:
         assert isinstance(pow_op_odd[0], hqml.ModeSwap)
 
 
+@pytest.mark.unit
 class TestFourier:
     def test_init(self):
         """Test the __init__ method."""
@@ -100,6 +104,7 @@ class TestFourier:
         assert isinstance(adj_op, hqml.Rotation)
 
 
+@pytest.mark.unit
 class TestQuadX:
     def test_init(self):
         """Test the __init__ method."""
@@ -115,6 +120,7 @@ class TestQuadX:
         assert op.diagonalizing_gates() == []
 
 
+@pytest.mark.unit
 class TestQuadP:
     def test_init(self):
         """Test the __init__ method."""
@@ -132,6 +138,7 @@ class TestQuadP:
         assert isinstance(gates[0], hqml.Rotation)
 
 
+@pytest.mark.unit
 class TestQuadOperator:
     def test_init(self):
         """Test the __init__ method."""
@@ -150,6 +157,7 @@ class TestQuadOperator:
         assert isinstance(gates[0], hqml.Rotation)
 
 
+@pytest.mark.unit
 class TestNumberOperator:
     def test_init(self):
         """Test the __init__ method."""
@@ -165,6 +173,7 @@ class TestNumberOperator:
         assert op.diagonalizing_gates() == []
 
 
+@pytest.mark.unit
 class TestFockStateProjector:
     def test_init(self):
         """Test the __init__ method."""
@@ -181,6 +190,7 @@ class TestFockStateProjector:
         assert op.diagonalizing_gates() == []
 
 
+@pytest.mark.unit
 class TestSelectiveNumberArbitraryPhase:
     def test_init(self):
         op = hqml.SelectiveNumberArbitraryPhase(0.5, 1, 1)

--- a/test/ops/test_hybrid.py
+++ b/test/ops/test_hybrid.py
@@ -1,10 +1,12 @@
 # SPDX-FileCopyrightText: 2025 Battelle Memorial Institute
 # SPDX-License-Identifier: BSD-2-Clause
 import pennylane as qml
+import pytest
 
 import hybridlane as hqml
 
 
+@pytest.mark.unit
 class TestConditionalRotation:
     def test_init(self):
         op = hqml.ConditionalRotation(0.5, wires=[0, 1])
@@ -36,6 +38,7 @@ class TestConditionalRotation:
         assert isinstance(simplified_op, qml.Identity)
 
 
+@pytest.mark.unit
 class TestConditionalParity:
     def test_init(self):
         op = hqml.ConditionalParity(wires=[0, 1])
@@ -57,6 +60,7 @@ class TestConditionalParity:
         assert isinstance(adj_op, hqml.ConditionalRotation)
 
 
+@pytest.mark.unit
 class TestSelectiveQubitRotation:
     def test_init(self):
         op = hqml.SelectiveQubitRotation(0.5, 0.3, 1, wires=[0, 1])
@@ -85,6 +89,7 @@ class TestSelectiveQubitRotation:
         assert isinstance(simplified_op, qml.Identity)
 
 
+@pytest.mark.unit
 class TestJaynesCummings:
     def test_init(self):
         op = hqml.JaynesCummings(0.5, 0.3, wires=[0, 1])
@@ -112,6 +117,7 @@ class TestJaynesCummings:
         assert isinstance(simplified_op, qml.Identity)
 
 
+@pytest.mark.unit
 class TestAntiJaynesCummings:
     def test_init(self):
         op = hqml.AntiJaynesCummings(0.5, 0.3, wires=[0, 1])
@@ -139,6 +145,7 @@ class TestAntiJaynesCummings:
         assert isinstance(simplified_op, qml.Identity)
 
 
+@pytest.mark.unit
 class TestRabi:
     def test_init(self):
         op = hqml.Rabi(0.5, 0.3, wires=[0, 1])
@@ -166,6 +173,7 @@ class TestRabi:
         assert isinstance(simplified_op, qml.Identity)
 
 
+@pytest.mark.unit
 class TestConditionalDisplacement:
     def test_init(self):
         op = hqml.ConditionalDisplacement(0.5, 0.3, wires=[0, 1])
@@ -193,6 +201,7 @@ class TestConditionalDisplacement:
         assert isinstance(simplified_op, qml.Identity)
 
 
+@pytest.mark.unit
 class TestConditionalBeamsplitter:
     def test_init(self):
         op = hqml.ConditionalBeamsplitter(0.5, 0.3, wires=[0, 1, 2])
@@ -220,6 +229,7 @@ class TestConditionalBeamsplitter:
         assert isinstance(simplified_op, qml.Identity)
 
 
+@pytest.mark.unit
 class TestConditionalTwoModeSqueezing:
     def test_init(self):
         op = hqml.ConditionalTwoModeSqueezing(0.5, 0.3, wires=[0, 1, 2])
@@ -247,6 +257,7 @@ class TestConditionalTwoModeSqueezing:
         assert isinstance(simplified_op, qml.Identity)
 
 
+@pytest.mark.unit
 class TestConditionalTwoModeSum:
     def test_init(self):
         op = hqml.ConditionalTwoModeSum(0.5, wires=[0, 1, 2])
@@ -274,6 +285,7 @@ class TestConditionalTwoModeSum:
         assert isinstance(simplified_op, qml.Identity)
 
 
+@pytest.mark.unit
 class TestEchoedConditionalDisplacement:
     def test_init(self):
         op = hqml.EchoedConditionalDisplacement(0.5, 0, wires=[0, 1])

--- a/test/sa/test_infer_wires.py
+++ b/test/sa/test_infer_wires.py
@@ -9,6 +9,7 @@ import hybridlane as hqml
 from hybridlane import sa
 
 
+@pytest.mark.unit
 class TestWireTypeChecking:
     @pytest.mark.parametrize("obs", (hqml.NumberOperator, hqml.QuadX))
     def test_no_operations(self, obs):

--- a/test/templates/test_fock_state.py
+++ b/test/templates/test_fock_state.py
@@ -16,6 +16,7 @@ class TestFockState:
         assert set(op.resource_params.keys()) == op.resource_keys
 
     @pytest.mark.integration
+    @pytest.mark.bq
     @pytest.mark.parametrize("n", range(1, 10, 2))
     def test_expval(self, n):
         dev = qml.device("bosonicqiskit.hybrid", max_fock_level=16)
@@ -29,6 +30,7 @@ class TestFockState:
         assert np.isclose(expval, n)
 
     @pytest.mark.integration
+    @pytest.mark.bq
     @pytest.mark.parametrize("n", range(1, 10, 2))
     def test_var(self, n):
         dev = qml.device("bosonicqiskit.hybrid", max_fock_level=16)

--- a/test/templates/test_fock_state.py
+++ b/test/templates/test_fock_state.py
@@ -7,14 +7,15 @@ import pytest
 
 import hybridlane as hqml
 
-qml.decomposition.enable_graph()
 
-
+@pytest.mark.usefixtures("enable_graph_decomp")
 class TestFockState:
+    @pytest.mark.unit
     def test_resource_rep(self):
         op = hqml.FockState(5, [0, 1])
         assert set(op.resource_params.keys()) == op.resource_keys
 
+    @pytest.mark.integration
     @pytest.mark.parametrize("n", range(1, 10, 2))
     def test_expval(self, n):
         dev = qml.device("bosonicqiskit.hybrid", max_fock_level=16)
@@ -27,6 +28,7 @@ class TestFockState:
         expval = circuit(n)
         assert np.isclose(expval, n)
 
+    @pytest.mark.integration
     @pytest.mark.parametrize("n", range(1, 10, 2))
     def test_var(self, n):
         dev = qml.device("bosonicqiskit.hybrid", max_fock_level=16)

--- a/test/templates/test_non_abelian_qsp.py
+++ b/test/templates/test_non_abelian_qsp.py
@@ -25,6 +25,7 @@ def cat_state_probs(alpha, ns, odd: bool):
 
 @pytest.mark.slow
 class TestSqueezedCatState:
+    @pytest.mark.integration
     @pytest.mark.parametrize(
         "alpha,parity", itertools.product([3, 4, 5, 6], ("even", "odd"))
     )
@@ -47,6 +48,7 @@ class TestSqueezedCatState:
         else:
             assert parity_expval <= -0.95
 
+    @pytest.mark.integration
     @pytest.mark.parametrize("alpha,parity", [(3, "even"), (6, "odd")])
     def test_qubit_fidelity_and_mean_photon_count(self, alpha, parity):
         dev = qml.device("bosonicqiskit.hybrid", max_fock_level=256)
@@ -68,6 +70,7 @@ class TestSqueezedCatState:
 
 
 class TestGKPState:
+    @pytest.mark.integration
     @pytest.mark.slow
     @pytest.mark.parametrize("codeword", (0, 1))
     def test_stabilizer(self, codeword):
@@ -89,6 +92,7 @@ class TestGKPState:
         stabilizer_expval = circuit(codeword, 0.34)
         assert stabilizer_expval >= 0.99  # from table 3
 
+    @pytest.mark.integration
     @pytest.mark.parametrize("codeword", (0, 1))
     def test_error(self, codeword):
         fock_level = 256

--- a/test/templates/test_non_abelian_qsp.py
+++ b/test/templates/test_non_abelian_qsp.py
@@ -24,6 +24,7 @@ def cat_state_probs(alpha, ns, odd: bool):
 
 
 @pytest.mark.slow
+@pytest.mark.bq
 class TestSqueezedCatState:
     @pytest.mark.integration
     @pytest.mark.parametrize(
@@ -69,6 +70,7 @@ class TestSqueezedCatState:
         assert np.allclose(expval_n, expected_mean, rtol=1e-2)
 
 
+@pytest.mark.bq
 class TestGKPState:
     @pytest.mark.integration
     @pytest.mark.slow


### PR DESCRIPTION
Following PennyLane's example, this adds several useful test markers: `unit`, `integration`, `jax`, and `torch` are all just like PennyLane. Also adds `bq` to toggle tests involving Bosonic Qiskit (which happen to be most of them). Switching off integration tests or bosonic qiskit can lead to much faster test times.

Also makes hybridlane importable without matplotlib, fixing a bug.