### PR TITLE
`qp.math` equivalent module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ Issues = "https://github.com/pnnl/hybridlane/issues"
 [project.optional-dependencies]
 bq = [
     "bosonic-qiskit>=15.0",
-    "sparse>=0.17.0",
 ]
 all = [
     "hybridlane[bq,qscout]"

--- a/src/hybridlane/__init__.py
+++ b/src/hybridlane/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Battelle Memorial Institute
 # SPDX-License-Identifier: BSD-2-Clause
 
-from hybridlane import decomposition, ops, sa, transforms  # noqa: F401
+from hybridlane import decomposition, math, ops, sa, transforms  # noqa: F401
 from hybridlane.drawer import draw_mpl  # noqa: F401
 from hybridlane.io import to_openqasm  # noqa: F401
 from hybridlane.measurements import expval, sample, state, var  # noqa: F401

--- a/src/hybridlane/devices/bosonic_qiskit/simulate.py
+++ b/src/hybridlane/devices/bosonic_qiskit/simulate.py
@@ -89,19 +89,16 @@ def simulate(
 def analytic_expval(
     state: Statevector, result: QiskitResult, obs: np.ndarray
 ) -> np.ndarray:
-    from qiskit.quantum_info import Operator
-
-    return np.array(state.expectation_value(Operator(obs)).real)
+    return hqml.math.expectation_value(obs, state.data)
 
 
 def analytic_var(
     state: Statevector, result: QiskitResult, obs: np.ndarray
 ) -> np.ndarray:
-    from qiskit.quantum_info import Operator
-
-    op = Operator(obs)
-    var = state.expectation_value(op**2) - state.expectation_value(op) ** 2
-    return np.array(var.real)
+    exp = hqml.math.expectation_value(obs, state.data)
+    exp2 = hqml.math.expectation_value(obs @ obs, state.data)
+    var = exp2 - exp**2
+    return var
 
 
 def analytic_probs(
@@ -122,27 +119,12 @@ def analytic_state(
     obs: np.ndarray,
     regmapper: RegisterMapping,
 ) -> np.ndarray:
-    source_wires = Wires(
-        range(len(regmapper.wire_order))
-    )  # auto pulling from ALL hybridlane wires
-    destination_wires = (
-        regmapper.wire_order
-    )  # how those wires map to the bq statevector wires
-    state_size = state.data.shape[0]
-
-    out_vector = -1 * np.ones(state.data.shape, dtype=complex)
-
-    order = permute_subsystems(
-        sp.diags([range(state_size)], [0], dtype=int),  # matrix
-        source_wires,  # 'observable' wires
-        destination_wires,  # 'statevector' wires
-        regmapper,
-        qiskit_order=True,
-    ).diagonal()
-    for i, idx in enumerate(order):
-        out_vector[int(idx)] = state.data[i]
-
-    assert not np.any(out_vector == -1)
+    bq_wires = regmapper.wire_order[::-1]  # inverted for qiskit ordering
+    wire_order = tuple(range(len(bq_wires)))
+    wire_dims = {w: regmapper.truncation.dim(w) for w in regmapper.wire_order}
+    out_vector = hqml.math.expand_vector(
+        state.data, bq_wires, wire_order=wire_order, wire_dims=wire_dims
+    )
     return out_vector
 
 
@@ -153,7 +135,6 @@ analytic_measurement_map: dict[
     ExpectationMP: analytic_expval,
     VarianceMP: analytic_var,
     ProbabilityMP: analytic_probs,
-    # StateMP: analytic_state,  # Don't even need StateMP if the device handles the calculation
 }
 
 
@@ -244,28 +225,16 @@ def get_observable_matrix(
         mat = get_sparse_observable_matrix(op, *cutoffs, hbar=hbar)
         op_mats.append(mat)
 
-    # Get wire dimensions
-    statevector_wires = regmapper.wire_order
-    obs_wires = Wires.all_wires([o.wires for o in op_list])
-
-    # Find the Hilbert dimension of the remaining (identity) operators and add an I gate
-    if remaining_wires := statevector_wires - obs_wires:
-        dims = regmapper.truncation.shape(remaining_wires)
-        dim = np.prod(dims)
-        op_mats.append(sp.eye_array(dim, format="csc"))  # type: ignore
-        obs_wires = Wires.all_wires([obs_wires, remaining_wires])
-
-    # Perform full tensor product and reorder the subsystem wires from those in op_list to the statevector wires
     composite_matrix = functools.reduce(sp.kron, op_mats)
-    composite_matrix = permute_subsystems(
-        composite_matrix,
-        obs_wires,
-        statevector_wires,
-        regmapper,
-        qiskit_order=True,
-    )
 
-    return composite_matrix.todense()
+    # Get wire dimensions
+    statevector_wires = regmapper.wire_order[::-1]  # reverse for qiskit ordering
+    obs_wires = Wires.all_wires([o.wires for o in op_list])
+    wire_dims = {w: regmapper.truncation.dim(w) for w in statevector_wires}
+    mat = hqml.math.expand_matrix(
+        composite_matrix, obs_wires, wire_order=statevector_wires, wire_dims=wire_dims
+    )
+    return mat.todense()
 
 
 def make_cv_circuit(
@@ -492,48 +461,6 @@ def pad_statevector_to_truncation(
         state = np.pad(state, pad_width, mode="constant", constant_values=0)
 
     return state
-
-
-# todo: write unit tests for this function
-def permute_subsystems(
-    A: sp.csc_array,
-    source_wires: Wires,
-    destination_wires: Wires,
-    regmapper: RegisterMapping,
-    qiskit_order: bool = False,
-) -> sp.csc_array:
-    # Dedicated sparse library that allows for proper nd-arrays unlike scipy.sparse
-    import sparse
-
-    # We reverse the destination to match qiskit little endian ordering.
-    if qiskit_order:
-        destination_wires = destination_wires[::-1]
-
-    if source_wires == destination_wires:
-        return A
-
-    # Get the order of the input and output axes, which will allow us to
-    # compute the appropriate permutation
-    source_oaxes = tuple(range(len(source_wires)))
-    dest_oaxes = tuple(destination_wires.indices(source_wires))
-
-    # Here we identify the permutation from x -> y
-    n = len(source_oaxes)
-    source_axes = source_oaxes + tuple(i + n for i in source_oaxes)
-    dest_axes = dest_oaxes + tuple(i + n for i in dest_oaxes)
-    perm = tuple(map(int, np.argsort(dest_axes)[np.argsort(source_axes)]))
-
-    # convert to sparse library for axes permutation
-    # Reshape the operator from (d, d) to (o1, ..., on, i1, ..., in) where oi == ii
-    hilbert_dim: int = A.shape[0]
-    source_dims = regmapper.truncation.shape(source_wires)
-    coo_A = sparse.COO.from_scipy_sparse(A)
-    coo_A = coo_A.reshape(2 * source_dims)  # first #wires are output
-    coo_A = coo_A.transpose(perm)
-
-    # Convert back to regular matrix shape and scipy format
-    coo_A = coo_A.reshape((hilbert_dim, hilbert_dim))
-    return coo_A.tocsc()
 
 
 def analytic_measurement(

--- a/src/hybridlane/math/__init__.py
+++ b/src/hybridlane/math/__init__.py
@@ -2,9 +2,12 @@
 # SPDX-License-Identifier: BSD-2-Clause
 r"""A wrapper around :mod:`pennylane.math` providing tensor-library agnostic functions."""
 
+import autoray as ar
 from pennylane import math as pl_math
 
 from .matrix_manipulation import expand_matrix, expand_vector
+
+dag = ar.dag
 
 
 def __getattr__(name):
@@ -14,8 +17,8 @@ def __getattr__(name):
 
 def __dir__():
     # Include the functions from pennylane math library in the dir() output
-    our_stuff = set(list(globals().keys())) - {"pl_math"}
+    our_stuff = set(list(globals().keys())) - {"pl_math", "ar"}
     return list(our_stuff | set(pl_math.__dir__()))
 
 
-__all__ = ["expand_matrix", "expand_vector"] + pl_math.__all__
+__all__ = ["expand_matrix", "expand_vector", "dag"] + pl_math.__all__

--- a/src/hybridlane/math/__init__.py
+++ b/src/hybridlane/math/__init__.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 Battelle Memorial Institute
+# SPDX-License-Identifier: BSD-2-Clause
+r"""A wrapper around :mod:`pennylane.math` providing tensor-library agnostic functions."""
+
+from pennylane import math as pl_math
+
+from .matrix_manipulation import expand_matrix, expand_vector
+
+
+def __getattr__(name):
+    # Fallback to pennylane math library so that users can just use our version seamlessly
+    return getattr(pl_math, name)
+
+
+def __dir__():
+    # Include the functions from pennylane math library in the dir() output
+    our_stuff = set(list(globals().keys())) - {"pl_math"}
+    return list(our_stuff | set(pl_math.__dir__()))
+
+
+__all__ = ["expand_matrix", "expand_vector"] + pl_math.__all__

--- a/src/hybridlane/math/matrix_manipulation.py
+++ b/src/hybridlane/math/matrix_manipulation.py
@@ -1,0 +1,409 @@
+# SPDX-FileCopyrightText: 2025 Battelle Memorial Institute
+# SPDX-License-Identifier: BSD-2-Clause
+
+from collections import defaultdict
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, cast
+
+import numpy as np
+import scipy as sp
+from pennylane import math
+from pennylane.typing import TensorLike
+from pennylane.wires import Wires, WiresLike
+from scipy.sparse import coo_array, sparray
+from typing_extensions import overload
+
+if TYPE_CHECKING:
+    from torch import Tensor as TorchTensor
+
+
+@overload
+def expand_matrix(
+    mat: TensorLike,
+    wires: WiresLike,
+    wire_dims: Mapping[Any, int] | None = None,
+    wire_order: WiresLike | None = None,
+    sparse_format: str = "csr",
+) -> TensorLike: ...
+
+
+@overload
+def expand_matrix(
+    mat: sparray,
+    wires: WiresLike,
+    wire_dims: Mapping[Any, int] | None = None,
+    wire_order: WiresLike | None = None,
+    sparse_format: str = "csr",
+) -> sparray: ...
+
+
+def expand_matrix(
+    mat: TensorLike | sparray,
+    wires: WiresLike,
+    wire_dims: Mapping[Any, int] | None = None,
+    wire_order: WiresLike | None = None,
+    sparse_format: str = "csr",
+) -> TensorLike | sparray:
+    r"""Equivalent of :func:`pennylane.math.expand_matrix`
+
+    Compared to the PennyLane version, this supports variable dimensions per subsystem, passed
+    in through the ``wire_dims`` argument. If not specified, it defaults to 2 for all wires, which is the behavior of PennyLane.
+
+    Args:
+        mat: The matrix to expand. Must be square and have shape ``(d, d)`` where ``d`` is
+            the composite dimension of the wires in ``wires``. Can also have a batch dimension.
+
+        wires: The wires that the matrix acts on.
+
+        wire_dims: A mapping from wire labels to their dimensions. If not specified, all wires
+            are assumed to have dimension 2.
+
+        wire_order: The order of wires to use in the output matrix. If not specified, the
+            order of wires in the output will be the same as the order of wires in the input.
+
+        sparse_format: The sparse format to use if the input is a sparse matrix. Default is
+            "csr".
+    """
+    # Replicate pennylane behavior by assuming qubit dimension if not specified
+    if wire_dims is None:
+        wire_dims = defaultdict(lambda: 2)  # type: ignore[assignment]
+
+    wires = Wires(wires)
+    wire_order = Wires(wire_order or [])
+    if not wire_order or wire_order == wires:
+        return mat
+
+    shape = math.shape(mat)
+    if not wires and shape == (1, 1):  # pyright: ignore[reportCallIssue]
+        return complex(mat[0, 0])
+
+    if wires - wire_order:
+        raise ValueError("The wire_order must contain every wire in wires.")
+
+    interface = math.get_interface(mat)
+    batch_dim = shape[0] if len(shape) == 3 else None
+
+    # First step is to find the smallest subset of `wire_order` that contains every wire in
+    # `wires`. This might have extra wires, so then we need to pad it with identity and then
+    # permute it to match that subset order.
+    indices = [wire_order.index(w) for w in wires]
+    min_idx = min(indices)
+    max_idx = max(indices)
+    before_wire_order = wire_order[:min_idx]
+    mid_wire_order = wire_order[min_idx : max_idx + 1]
+    after_wire_order = wire_order[max_idx + 1 :]
+    extra_wires = (
+        mid_wire_order - wires
+    )  # all the wires that we'll need to put identity on
+
+    # Now we'll pad all the extra wires with identity
+    if extra_wires:
+        dim = int(math.prod([wire_dims[wire] for wire in extra_wires]))
+        id_mat = math.cast_like(math.eye(dim, like=interface), mat)
+        mat = _kron_with_batch(mat, id_mat, interface, batch_dim)
+
+    # Permute from sub_wire_order to subset, which is a subset of our target wire order.
+    # After this, we'll only need to pad the beginning or end.
+    curr_wire_order = (
+        wires + extra_wires
+    )  # subset reordered so that all extras come at the end
+    if interface == "scipy":
+        mat = cast(sparray, mat)
+        mat = permute_sparse_matrix(
+            mat, curr_wire_order, mid_wire_order, wire_dims, sparse_format
+        )
+    else:
+        mat = cast(TensorLike, mat)
+        mat = permute_dense_matrix(mat, curr_wire_order, mid_wire_order, wire_dims)
+
+    # Now pad the before and after sections with identity too
+    if before_wire_order:
+        dim = int(math.prod([wire_dims[wire] for wire in before_wire_order]))
+        id_mat = math.cast_like(math.eye(dim, like=interface), mat)
+        mat = _kron_with_batch(id_mat, mat, interface, batch_dim)
+
+    if after_wire_order:
+        dim = int(math.prod([wire_dims[wire] for wire in after_wire_order]))
+        id_mat = math.cast_like(math.eye(dim, like=interface), mat)
+        mat = _kron_with_batch(mat, id_mat, interface, batch_dim)
+
+    return mat
+
+
+def _kron(
+    mat1: TensorLike | sparray,
+    mat2: TensorLike | sparray,
+    interface: str,
+) -> TensorLike | sparray:
+    if interface == "torch":
+        # According to pennylane, this avoids a crash
+        mat1 = cast("TorchTensor", mat1).contiguous()  # pyright: ignore[reportAssignmentType]
+        mat2 = cast("TorchTensor", mat2).contiguous()  # pyright: ignore[reportAssignmentType]
+
+    if interface == "scipy":
+        mat = sp.sparse.kron(mat1, mat2, format="coo")
+        cast(coo_array, mat).eliminate_zeros()
+        return cast(sparray, mat)
+
+    return math.kron(mat1, mat2, like=interface)
+
+
+def _kron_with_batch(
+    mat1: TensorLike | sparray,
+    mat2: TensorLike | sparray,
+    interface: str,
+    batch_dim: int | None,
+) -> TensorLike | sparray:
+    if batch_dim is None:
+        return _kron(mat1, mat2, interface)
+
+    matrices = [_kron(m, mat2, interface) for m in mat1]
+    return math.stack(matrices, like=interface)
+
+
+def permute_dense_matrix(
+    mat: TensorLike,
+    wires: Wires,
+    wire_order: Wires,
+    wire_dims: Mapping[Any, int],
+) -> TensorLike:
+    shape = math.shape(mat)
+    batch_dim = shape[0] if len(shape) == 3 else None
+
+    # Here we identify the permutation from x -> y
+    perm = wires.indices(wire_order)
+    perm = tuple(perm) + tuple(i + len(wires) for i in perm)
+    perm = tuple(i + bool(batch_dim) for i in perm)
+
+    # Reshape the operator from (d, d) to (o1, ..., on, i1, ..., in) where oi == ii
+    source_dims = tuple(wire_dims[wire] for wire in wires)
+    expanded_shape = (batch_dim,) if batch_dim else () + source_dims + source_dims
+    mat = math.reshape(mat, expanded_shape)
+    mat = math.transpose(mat, perm)
+    mat = math.reshape(mat, shape)
+    return mat
+
+
+def permute_sparse_matrix(
+    mat: sparray,
+    wires: Wires,
+    wire_order: Wires,
+    wire_dims: Mapping[Any, int],
+    format: str,
+) -> sparray:
+    perm = tuple(wire_order.indices(wires))
+    dims = tuple(wire_dims[wire] for wire in wires)
+    P = build_sparse_permutation_matrix(dims, perm)
+    assert P.shape[-2:] == mat.shape[-2:], (
+        "Permutation matrix must be the same shape as the input matrix."
+    )
+    result = P @ mat @ P.T
+    return result.asformat(format)
+
+
+def build_sparse_permutation_matrix(
+    dims: tuple[int, ...], perm: tuple[int, ...]
+) -> sparray:
+    """
+    Build sparse permutation matrix for subsystem reordering.
+
+    Args:
+        dims: tuple of subsystem dimensions (d1, ..., dn)
+        perm: permutation of subsystems (0-indexed)
+              e.g., (1, 0, 2) swaps first two subsystems
+
+    Returns:
+        Sparse permutation matrix P in CSR format, shape (d, d) where d = prod(dims)
+        Use as: M_permuted = P @ M @ P.T
+    """
+    d = int(math.prod(dims))
+
+    # New dimensions after permutation
+    new_dims = tuple(dims[i] for i in perm)
+
+    # We'll collect the nonzero entries (row, col, data)
+    rows = []
+    cols = []
+
+    # Iterate over all possible multi-indices
+    # For efficiency, we iterate over flat indices and convert
+    for old_idx in range(d):
+        # Convert flat index to multi-index in original ordering
+        multi_idx = np.unravel_index(old_idx, dims)
+
+        # Apply permutation to get new multi-index
+        new_multi_idx = tuple(multi_idx[i] for i in perm)
+
+        # Convert back to flat index in new ordering
+        new_idx = np.ravel_multi_index(new_multi_idx, new_dims)
+
+        # P[new_idx, old_idx] = 1
+        rows.append(new_idx)
+        cols.append(old_idx)
+
+    # Create sparse matrix with all 1s
+    data = math.ones(d, dtype=np.int8)  # or dtype=np.float64 if preferred
+
+    P = coo_array((data, (rows, cols)), shape=(d, d))
+    return P.tocsr()
+
+
+@overload
+def expand_vector(
+    vec: TensorLike,
+    wires: WiresLike,
+    wire_dims: Mapping[Any, int] | None = None,
+    wire_order: WiresLike | None = None,
+    sparse_format: str = "csr",
+) -> TensorLike: ...
+
+
+@overload
+def expand_vector(
+    vec: sparray,
+    wires: WiresLike,
+    wire_dims: Mapping[Any, int] | None = None,
+    wire_order: WiresLike | None = None,
+    sparse_format: str = "csr",
+) -> sparray: ...
+
+
+def expand_vector(
+    vec: TensorLike | sparray,
+    wires: WiresLike,
+    wire_dims: Mapping[Any, int] | None = None,
+    wire_order: WiresLike | None = None,
+    sparse_format: str = "csr",
+) -> TensorLike | sparray:
+    r"""Equivalent of :func:`pennylane.math.expand_vector`
+
+    Compared to the PennyLane version, this supports variable dimensions per subsystem, passed
+    in through the ``wire_dims`` argument. If not specified, it defaults to 2 for all wires, which is the behavior of PennyLane.
+
+    Args:
+        vec: The vector to expand. Must be square and have shape ``(d,)`` where ``d`` is
+            the composite dimension of the wires in ``wires``. Can also have a batch dimension.
+
+        wires: The wires that the matrix acts on.
+
+        wire_dims: A mapping from wire labels to their dimensions. If not specified, all wires
+            are assumed to have dimension 2.
+
+        wire_order: The order of wires to use in the output vector. If not specified, the
+            order of wires in the output will be the same as the order of wires in the input.
+
+        sparse_format: The sparse format to use if the input is a sparse vector. Default is
+            "csr".
+    """
+    # Replicate pennylane behavior by assuming qubit dimension if not specified
+    if wire_dims is None:
+        wire_dims = defaultdict(lambda: 2)  # type: ignore[assignment]
+
+    wires = Wires(wires)
+    wire_order = Wires(wire_order or [])
+    if not wire_order or wire_order == wires:
+        return vec
+
+    shape = math.shape(vec)
+    if not wires and shape == (1,):  # pyright: ignore[reportCallIssue]
+        return complex(vec[0])
+
+    if wires - wire_order:
+        raise ValueError("The wire_order must contain every wire in wires.")
+
+    interface = math.get_interface(vec)
+    batch_dim = shape[0] if len(shape) == 2 else None
+
+    # First step is to find the smallest subset of `wire_order` that contains every wire in
+    # `wires`. This might have extra wires, so then we need to pad it with zero and then
+    # permute it to match that subset order.
+    indices = wire_order.indices(wires)
+    min_idx = min(indices)
+    max_idx = max(indices)
+    before_wire_order = wire_order[:min_idx]
+    mid_wire_order = wire_order[min_idx : max_idx + 1]
+    after_wire_order = wire_order[max_idx + 1 :]
+    extra_wires = mid_wire_order - wires
+
+    # Now we'll pad all the extra wires with zeros
+    if extra_wires:
+        dim = int(math.prod([wire_dims[wire] for wire in extra_wires]))
+        id_vec = math.cast_like(_identity_vector(dim, like=interface), vec)
+        vec = _kron_with_batch(vec, id_vec, interface, batch_dim)
+
+    # Permute from sub_wire_order to subset, which is a subset of our target wire order.
+    # After this, we'll only need to pad the beginning or end.
+    curr_wire_order = (
+        wires + extra_wires
+    )  # subset reordered so that all extras come at the end
+    if interface == "scipy":
+        vec = cast(sparray, vec)
+        vec = permute_sparse_vector(
+            vec, curr_wire_order, mid_wire_order, wire_dims, sparse_format
+        )
+    else:
+        vec = cast(TensorLike, vec)
+        vec = permute_dense_vector(vec, curr_wire_order, mid_wire_order, wire_dims)
+
+    # Now pad the before and after sections with zeros too
+    if before_wire_order:
+        dim = int(math.prod([wire_dims[wire] for wire in before_wire_order]))
+        id_vec = math.cast_like(_identity_vector(dim, like=interface), vec)
+        vec = _kron_with_batch(id_vec, vec, interface, batch_dim)
+
+    if after_wire_order:
+        dim = int(math.prod([wire_dims[wire] for wire in after_wire_order]))
+        id_vec = math.cast_like(_identity_vector(dim, like=interface), vec)
+        vec = _kron_with_batch(vec, id_vec, interface, batch_dim)
+
+    return vec
+
+
+def _identity_vector(dim: int, like: str) -> TensorLike | sparray:
+    if like == "scipy":
+        vec = sp.sparse.coo_array(([1], ([0],)), shape=(dim,))
+        return cast(sparray, vec)
+
+    if like == "jax":
+        vec = math.zeros(dim, like=like)
+        vec = vec.at[0].set(1)
+        return vec
+
+    vec = math.zeros(dim, like=like)
+    vec[0] = 1
+    return vec
+
+
+def permute_dense_vector(
+    vec: TensorLike,
+    wires: Wires,
+    wire_order: Wires,
+    wire_dims: Mapping[Any, int],
+) -> TensorLike:
+    shape = math.shape(vec)
+    batch_dim = shape[0] if len(shape) == 2 else None
+
+    # Here we identify the permutation from x -> y
+    perm = wires.indices(wire_order)
+    perm = tuple(i + bool(batch_dim) for i in perm)
+
+    source_dims = tuple(wire_dims[wire] for wire in wires)
+    expanded_shape = (batch_dim,) if batch_dim else () + source_dims
+    vec = math.reshape(vec, expanded_shape)
+    vec = math.transpose(vec, perm)
+    vec = math.reshape(vec, shape)
+    return vec
+
+
+def permute_sparse_vector(
+    vec: sparray,
+    wires: Wires,
+    wire_order: Wires,
+    wire_dims: Mapping[Any, int],
+    format: str,
+) -> sparray:
+    perm = tuple(wire_order.indices(wires))
+    dims = tuple(wire_dims[wire] for wire in wires)
+    P = build_sparse_permutation_matrix(dims, perm)
+    result = P @ vec
+    return result.asformat(format)

--- a/test/devices/bosonic_qiskit/test_device.py
+++ b/test/devices/bosonic_qiskit/test_device.py
@@ -447,9 +447,6 @@ class TestStateMeasurements:
             )
 
         state, num1, num2 = circuit()
-        # hqml.draw_mpl(circuit, level="device")()[0].savefig(
-        #     f"test_{state_index}.png"
-        # )  # for debugging
         assert np.isclose(num1, 1)
         assert np.isclose(num2, 2)
         target = np.zeros((32,), dtype=complex)

--- a/test/math/test_init.py
+++ b/test/math/test_init.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 Battelle Memorial Institute
+# SPDX-License-Identifier: BSD-2-Clause
+import pytest
+from pennylane import math as pl_math
+
+from hybridlane import math
+
+
+@pytest.mark.unit
+def test_fallback_to_pennylane():
+    # Some examples of functions we haven't overriden
+    assert math.norm == pl_math.norm
+    assert math.choi_matrix == pl_math.choi_matrix
+
+
+@pytest.mark.unit
+def test_dir():
+    funcs = set(dir(math))
+    assert "pl_math" not in funcs

--- a/test/math/test_matrix_manipulation.py
+++ b/test/math/test_matrix_manipulation.py
@@ -1,0 +1,261 @@
+# SPDX-FileCopyrightText: 2025 Battelle Memorial Institute
+# SPDX-License-Identifier: BSD-2-Clause
+import itertools
+
+import pennylane as qp
+import pytest
+import scipy.sparse as sp
+
+from hybridlane import math
+from hybridlane.math.matrix_manipulation import permute_dense_matrix
+
+
+@pytest.mark.unit
+class TestPermuteDenseMatrix:
+    def test_same_wires(self):
+        # Construct an operator over wire dimensions (2, 4)
+        snap = math.diag(math.exp(1j * math.arange(4)))
+        csnap = math.block_diag([snap, snap.conj().T])
+        wires = qp.wires.Wires((0, 1))
+        wire_dims = {0: 2, 1: 4}
+        mat = permute_dense_matrix(csnap, wires, wires, wire_dims)
+
+        assert math.allclose(mat, csnap)
+
+    @pytest.mark.jax
+    def test_same_wires_jax(self):
+        from jax import numpy as jnp
+
+        snap = jnp.diag(jnp.exp(1j * jnp.arange(4)))
+        csnap = math.block_diag([snap, snap.conj().T])
+        wires = qp.wires.Wires((0, 1))
+        wire_dims = {0: 2, 1: 4}
+        mat = permute_dense_matrix(csnap, wires, wires, wire_dims)
+
+        assert math.get_interface(mat) == "jax"
+        assert jnp.allclose(mat, csnap)
+
+    def test_different_wires(self):
+        # Construct an operator over wire dimensions (2, 4)
+        #
+        # CSnap looks like
+        #   exp{diag([0, 1i, 2i, 3i]) + diag([0, -1i, -2i, -3i])}
+        phase = math.exp(1j * math.arange(4))
+        snap = math.diag(phase)
+        csnap = math.block_diag([snap, snap.conj().T])
+
+        # The transposed version interleaves the positive and negative phases:
+        #   exp{diag([0, 0, 1i, -1i, 2i, -2i, 3i, -3i])}
+        permuted_eigvals = math.zeros(8, dtype=complex)
+        permuted_eigvals[::2] = phase
+        permuted_eigvals[1::2] = phase.conj()
+        expected_mat = math.diag(permuted_eigvals)
+
+        wires = qp.wires.Wires((0, 1))
+        wire_order = qp.wires.Wires((1, 0))
+        wire_dims = {0: 2, 1: 4}
+        mat = permute_dense_matrix(csnap, wires, wire_order, wire_dims)
+
+        assert math.allclose(mat, expected_mat)
+
+    @pytest.mark.jax
+    def test_different_wires_jax(self):
+        from jax import numpy as jnp
+
+        # Construct an operator over wire dimensions (2, 4)
+        #
+        # CSnap looks like
+        #   exp{diag([0, 1i, 2i, 3i]) + diag([0, -1i, -2i, -3i])}
+        phase = jnp.exp(1j * jnp.arange(4))
+        snap = jnp.diag(phase)
+        csnap = math.block_diag([snap, snap.conj().T])
+
+        # The transposed version interleaves the positive and negative phases:
+        #   exp{diag([0, 0, 1i, -1i, 2i, -2i, 3i, -3i])}
+        permuted_eigvals = jnp.zeros(8, dtype=complex)
+        permuted_eigvals = permuted_eigvals.at[::2].set(phase)
+        permuted_eigvals = permuted_eigvals.at[1::2].set(phase.conj())
+        expected_mat = jnp.diag(permuted_eigvals)
+
+        wires = qp.wires.Wires((0, 1))
+        wire_order = qp.wires.Wires((1, 0))
+        wire_dims = {0: 2, 1: 4}
+        mat = permute_dense_matrix(csnap, wires, wire_order, wire_dims)
+
+        assert math.get_interface(mat) == "jax"
+        assert math.allclose(mat, expected_mat)
+
+
+@pytest.mark.unit
+class TestExpandMatrix:
+    def test_expand_before(self):
+        snap = math.diag(math.exp(1j * math.arange(4)))
+        expected_mat = math.block_diag([snap, snap])
+        wire_dims = {0: 4, 1: 2}
+        mat = math.expand_matrix(snap, (0,), wire_dims=wire_dims, wire_order=(1, 0))
+        assert math.allclose(mat, expected_mat)
+
+    @pytest.mark.jax
+    def test_expand_before_jax(self):
+        from jax import numpy as jnp
+
+        snap = jnp.diag(jnp.exp(1j * jnp.arange(4)))
+        expected_mat = math.block_diag([snap, snap])
+        wire_dims = {0: 4, 1: 2}
+        mat = math.expand_matrix(snap, (0,), wire_dims=wire_dims, wire_order=(1, 0))
+        assert math.get_interface(mat) == "jax"
+        assert math.allclose(mat, expected_mat)
+
+    @pytest.mark.torch
+    def test_expand_before_torch(self):
+        import torch
+
+        snap = torch.diag(torch.exp(1j * torch.arange(4)))
+        expected_mat = math.block_diag([snap, snap])
+        wire_dims = {0: 4, 1: 2}
+        mat = math.expand_matrix(snap, (0,), wire_dims=wire_dims, wire_order=(1, 0))
+        assert math.get_interface(mat) == "torch"
+        assert math.allclose(mat, expected_mat)
+
+    def test_expand_after(self):
+        snap = math.exp(1j * math.arange(4))
+        expected_diags = math.zeros(8, dtype=complex)
+        expected_diags[::2] = snap
+        expected_diags[1::2] = snap
+        expected_mat = math.diag(expected_diags)
+        wire_dims = {0: 4, 1: 2}
+        mat = math.expand_matrix(
+            math.diag(snap), (0,), wire_dims=wire_dims, wire_order=(0, 1)
+        )
+        assert math.allclose(mat, expected_mat)
+
+    def test_permutations(self):
+        mat1 = math.eye(2)
+        mat2 = 2 * math.eye(4)
+        mat3 = 3 * math.eye(4)
+        mats = [mat1, mat2, mat3]
+        mat = math.kron(mat1, mat2)
+        mat = math.kron(mat, mat3)
+        wires = (0, 1, 2)
+        wire_dims = {0: 2, 1: 4, 2: 4}
+        for wire_order in itertools.permutations(wires):
+            expanded_mat = math.expand_matrix(
+                mat, wires, wire_dims=wire_dims, wire_order=wire_order
+            )
+            reordered_mats = [mats[wire_order.index(wire)] for wire in wires]
+            expected_mat = math.kron(reordered_mats[0], reordered_mats[1])
+            expected_mat = math.kron(expected_mat, reordered_mats[2])
+            assert math.allclose(expanded_mat, expected_mat)
+
+    def test_permutations_sparse(self):
+        mat1 = sp.eye(2)
+        mat2 = 2 * sp.eye(4)
+        mat3 = 3 * sp.eye(4)
+        mats = [mat1, mat2, mat3]
+        mat = sp.kron(mat1, mat2)
+        mat = sp.kron(mat, mat3)
+        wires = (0, 1, 2)
+        wire_dims = {0: 2, 1: 4, 2: 4}
+        for wire_order in itertools.permutations(wires):
+            expanded_mat = math.expand_matrix(
+                mat, wires, wire_dims=wire_dims, wire_order=wire_order
+            )
+            reordered_mats = [mats[wire_order.index(wire)] for wire in wires]
+            expected_mat = sp.kron(reordered_mats[0], reordered_mats[1])
+            expected_mat = sp.kron(expected_mat, reordered_mats[2])
+            assert math.allclose(expanded_mat, expected_mat)
+
+
+@pytest.mark.unit
+class TestExpandVector:
+    def test_noop(self):
+        vec = math.array([1, 2, 3, 4])
+        wire_dims = {0: 2, 1: 2}
+        expanded_vec = math.expand_vector(vec, (0, 1), wire_dims=wire_dims)
+        assert math.allclose(expanded_vec, vec)
+
+    def test_reverse(self):
+        vec = math.arange(8)
+        expected_vec = math.asarray([0, 4, 2, 6, 1, 5, 3, 7])
+        expanded_vec = math.expand_vector(vec, (0, 1, 2), wire_order=(2, 1, 0))
+        assert math.allclose(expanded_vec, expected_vec)
+
+    @pytest.mark.jax
+    def test_reverse_jax(self):
+        from jax import numpy as jnp
+
+        vec = jnp.arange(8)
+        expected_vec = jnp.asarray([0, 4, 2, 6, 1, 5, 3, 7])
+        expanded_vec = math.expand_vector(vec, (0, 1, 2), wire_order=(2, 1, 0))
+        assert math.get_interface(expanded_vec) == "jax"
+        assert math.allclose(expanded_vec, expected_vec)
+
+    @pytest.mark.torch
+    def test_reverse_torch(self):
+        import torch
+
+        vec = torch.arange(8)
+        expected_vec = torch.asarray([0, 4, 2, 6, 1, 5, 3, 7])
+        expanded_vec = math.expand_vector(vec, (0, 1, 2), wire_order=(2, 1, 0))
+        assert math.get_interface(expanded_vec) == "torch"
+        assert math.allclose(expanded_vec, expected_vec)
+
+    def test_permuting(self):
+        wire_state = {0: 0, 1: 1, 2: 2}
+        state1 = math.asarray([1, 0])  # |0>
+        state2 = math.asarray([0, 1, 0, 0])  # |1>
+        state3 = math.asarray([0, 0, 1, 0])  # |2>
+        state = math.kron(state1, state2)
+        state = math.kron(state, state3)
+        wires = (0, 1, 2)
+        wire_dims = {0: 2, 1: 4, 2: 4}
+        for wire_order in itertools.permutations(wires):
+            expanded_state = math.expand_vector(
+                state, wires, wire_dims=wire_dims, wire_order=wire_order
+            )
+            multi_idx = tuple(wire_state[wire] for wire in wire_order)
+            dims = tuple(wire_dims[wire] for wire in wire_order)
+            target_idx = math.ravel_multi_index(multi_idx, dims)
+            nonzero_idx = math.nonzero(expanded_state)[0][0]
+            assert nonzero_idx == target_idx
+
+    def test_expand_before(self):
+        null_state = math.asarray([1, 0])
+        state = math.asarray([0, 0, 0, 1])
+        expected_state = math.kron(null_state, state)
+        wire_dims = {0: 2, 1: 4}
+        expanded_state = math.expand_vector(
+            state, (1,), wire_dims=wire_dims, wire_order=(0, 1)
+        )
+        assert math.allclose(expanded_state, expected_state)
+
+    def test_expand_before_sparse(self):
+        null_state = sp.csr_array([1, 0])
+        state = sp.csr_array([0, 0, 0, 1])
+        expected_state = sp.kron(null_state, state)
+        wire_dims = {0: 2, 1: 4}
+        expanded_state = math.expand_vector(
+            state, (1,), wire_dims=wire_dims, wire_order=(0, 1)
+        )
+        assert math.allclose(expanded_state, expected_state)
+
+    @pytest.mark.jax
+    def test_expand_before_jax(self):
+        null_state = math.asarray([1, 0], like="jax")
+        state = math.asarray([0, 0, 0, 1], like="jax")
+        expected_state = math.kron(null_state, state)
+        wire_dims = {0: 2, 1: 4}
+        expanded_state = math.expand_vector(
+            state, (1,), wire_dims=wire_dims, wire_order=(0, 1)
+        )
+        assert math.allclose(expanded_state, expected_state)
+
+    def test_expand_after(self):
+        null_state = math.asarray([1, 0])
+        state = math.asarray([0, 0, 0, 1])
+        expected_state = math.kron(state, null_state)
+        wire_dims = {0: 4, 1: 2}
+        expanded_state = math.expand_vector(
+            state, (0,), wire_dims=wire_dims, wire_order=(0, 1)
+        )
+        assert math.allclose(expanded_state, expected_state)

--- a/uv.lock
+++ b/uv.lock
@@ -719,11 +719,9 @@ all = [
     { name = "jaqalpaq" },
     { name = "python-constraint2" },
     { name = "qscout-gatemodels" },
-    { name = "sparse" },
 ]
 bq = [
     { name = "bosonic-qiskit" },
-    { name = "sparse" },
 ]
 qscout = [
     { name = "jaqalpaq" },
@@ -759,7 +757,6 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.9.2" },
     { name = "python-constraint2", marker = "extra == 'qscout'", specifier = ">=2.4.0" },
     { name = "qscout-gatemodels", marker = "extra == 'qscout'", specifier = ">=1.3.0" },
-    { name = "sparse", marker = "extra == 'bq'", specifier = ">=0.17.0" },
 ]
 provides-extras = ["bq", "all", "qscout"]
 
@@ -975,30 +972,6 @@ wheels = [
 ]
 
 [[package]]
-name = "llvmlite"
-version = "0.46.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/74/cd/08ae687ba099c7e3d21fe2ea536500563ef1943c5105bf6ab4ee3829f68e/llvmlite-0.46.0.tar.gz", hash = "sha256:227c9fd6d09dce2783c18b754b7cd9d9b3b3515210c46acc2d3c5badd9870ceb", size = 193456, upload-time = "2025-12-08T18:15:36.295Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/a1/2ad4b2367915faeebe8447f0a057861f646dbf5fbbb3561db42c65659cf3/llvmlite-0.46.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:82f3d39b16f19aa1a56d5fe625883a6ab600d5cc9ea8906cca70ce94cabba067", size = 37232766, upload-time = "2025-12-08T18:14:48.836Z" },
-    { url = "https://files.pythonhosted.org/packages/12/b5/99cf8772fdd846c07da4fd70f07812a3c8fd17ea2409522c946bb0f2b277/llvmlite-0.46.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a3df43900119803bbc52720e758c76f316a9a0f34612a886862dfe0a5591a17e", size = 56275175, upload-time = "2025-12-08T18:14:51.604Z" },
-    { url = "https://files.pythonhosted.org/packages/38/f2/ed806f9c003563732da156139c45d970ee435bd0bfa5ed8de87ba972b452/llvmlite-0.46.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de183fefc8022d21b0aa37fc3e90410bc3524aed8617f0ff76732fc6c3af5361", size = 55128630, upload-time = "2025-12-08T18:14:55.107Z" },
-    { url = "https://files.pythonhosted.org/packages/19/0c/8f5a37a65fc9b7b17408508145edd5f86263ad69c19d3574e818f533a0eb/llvmlite-0.46.0-cp311-cp311-win_amd64.whl", hash = "sha256:e8b10bc585c58bdffec9e0c309bb7d51be1f2f15e169a4b4d42f2389e431eb93", size = 38138652, upload-time = "2025-12-08T18:14:58.171Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/f8/4db016a5e547d4e054ff2f3b99203d63a497465f81ab78ec8eb2ff7b2304/llvmlite-0.46.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6b9588ad4c63b4f0175a3984b85494f0c927c6b001e3a246a3a7fb3920d9a137", size = 37232767, upload-time = "2025-12-08T18:15:00.737Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/85/4890a7c14b4fa54400945cb52ac3cd88545bbdb973c440f98ca41591cdc5/llvmlite-0.46.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3535bd2bb6a2d7ae4012681ac228e5132cdb75fefb1bcb24e33f2f3e0c865ed4", size = 56275176, upload-time = "2025-12-08T18:15:03.936Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/07/3d31d39c1a1a08cd5337e78299fca77e6aebc07c059fbd0033e3edfab45c/llvmlite-0.46.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4cbfd366e60ff87ea6cc62f50bc4cd800ebb13ed4c149466f50cf2163a473d1e", size = 55128630, upload-time = "2025-12-08T18:15:07.196Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/6b/d139535d7590a1bba1ceb68751bef22fadaa5b815bbdf0e858e3875726b2/llvmlite-0.46.0-cp312-cp312-win_amd64.whl", hash = "sha256:398b39db462c39563a97b912d4f2866cd37cba60537975a09679b28fbbc0fb38", size = 38138940, upload-time = "2025-12-08T18:15:10.162Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/ff/3eba7eb0aed4b6fca37125387cd417e8c458e750621fce56d2c541f67fa8/llvmlite-0.46.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:30b60892d034bc560e0ec6654737aaa74e5ca327bd8114d82136aa071d611172", size = 37232767, upload-time = "2025-12-08T18:15:13.22Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/54/737755c0a91558364b9200702c3c9c15d70ed63f9b98a2c32f1c2aa1f3ba/llvmlite-0.46.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6cc19b051753368a9c9f31dc041299059ee91aceec81bd57b0e385e5d5bf1a54", size = 56275176, upload-time = "2025-12-08T18:15:16.339Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/91/14f32e1d70905c1c0aa4e6609ab5d705c3183116ca02ac6df2091868413a/llvmlite-0.46.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bca185892908f9ede48c0acd547fe4dc1bafefb8a4967d47db6cf664f9332d12", size = 55128629, upload-time = "2025-12-08T18:15:19.493Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/a7/d526ae86708cea531935ae777b6dbcabe7db52718e6401e0fb9c5edea80e/llvmlite-0.46.0-cp313-cp313-win_amd64.whl", hash = "sha256:67438fd30e12349ebb054d86a5a1a57fd5e87d264d2451bcfafbbbaa25b82a35", size = 38138941, upload-time = "2025-12-08T18:15:22.536Z" },
-    { url = "https://files.pythonhosted.org/packages/95/ae/af0ffb724814cc2ea64445acad05f71cff5f799bb7efb22e47ee99340dbc/llvmlite-0.46.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:d252edfb9f4ac1fcf20652258e3f102b26b03eef738dc8a6ffdab7d7d341d547", size = 37232768, upload-time = "2025-12-08T18:15:25.055Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/19/5018e5352019be753b7b07f7759cdabb69ca5779fea2494be8839270df4c/llvmlite-0.46.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:379fdd1c59badeff8982cb47e4694a6143bec3bb49aa10a466e095410522064d", size = 56275173, upload-time = "2025-12-08T18:15:28.109Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/c9/d57877759d707e84c082163c543853245f91b70c804115a5010532890f18/llvmlite-0.46.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e8cbfff7f6db0fa2c771ad24154e2a7e457c2444d7673e6de06b8b698c3b269", size = 55128628, upload-time = "2025-12-08T18:15:31.098Z" },
-    { url = "https://files.pythonhosted.org/packages/30/a8/e61a8c2b3cc7a597073d9cde1fcbb567e9d827f1db30c93cf80422eac70d/llvmlite-0.46.0-cp314-cp314-win_amd64.whl", hash = "sha256:7821eda3ec1f18050f981819756631d60b6d7ab1a6cf806d9efefbe3f4082d61", size = 39153056, upload-time = "2025-12-08T18:15:33.938Z" },
-]
-
-[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1152,34 +1125,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
-]
-
-[[package]]
-name = "numba"
-version = "0.64.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "llvmlite" },
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/23/c9/a0fb41787d01d621046138da30f6c2100d80857bf34b3390dd68040f27a3/numba-0.64.0.tar.gz", hash = "sha256:95e7300af648baa3308127b1955b52ce6d11889d16e8cfe637b4f85d2fca52b1", size = 2765679, upload-time = "2026-02-18T18:41:20.974Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/a3/1a4286a1c16136c8896d8e2090d950e79b3ec626d3a8dc9620f6234d5a38/numba-0.64.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:766156ee4b8afeeb2b2e23c81307c5d19031f18d5ce76ae2c5fb1429e72fa92b", size = 2682938, upload-time = "2026-02-18T18:40:52.897Z" },
-    { url = "https://files.pythonhosted.org/packages/19/16/aa6e3ba3cd45435c117d1101b278b646444ed05b7c712af631b91353f573/numba-0.64.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d17071b4ffc9d39b75d8e6c101a36f0c81b646123859898c9799cb31807c8f78", size = 3747376, upload-time = "2026-02-18T18:40:54.925Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/f1/dd2f25e18d75fdf897f730b78c5a7b00cc4450f2405564dbebfaf359f21f/numba-0.64.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4ead5630434133bac87fa67526eacb264535e4e9a2d5ec780e0b4fc381a7d275", size = 3453292, upload-time = "2026-02-18T18:40:56.818Z" },
-    { url = "https://files.pythonhosted.org/packages/31/29/e09d5630578a50a2b3fa154990b6b839cf95327aa0709e2d50d0b6816cd1/numba-0.64.0-cp311-cp311-win_amd64.whl", hash = "sha256:f2b1fd93e7aaac07d6fbaed059c00679f591f2423885c206d8c1b55d65ca3f2d", size = 2749824, upload-time = "2026-02-18T18:40:58.392Z" },
-    { url = "https://files.pythonhosted.org/packages/70/a6/9fc52cb4f0d5e6d8b5f4d81615bc01012e3cf24e1052a60f17a68deb8092/numba-0.64.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:69440a8e8bc1a81028446f06b363e28635aa67bd51b1e498023f03b812e0ce68", size = 2683418, upload-time = "2026-02-18T18:40:59.886Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/89/1a74ea99b180b7a5587b0301ed1b183a2937c4b4b67f7994689b5d36fc34/numba-0.64.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f13721011f693ba558b8dd4e4db7f2640462bba1b855bdc804be45bbeb55031a", size = 3804087, upload-time = "2026-02-18T18:41:01.699Z" },
-    { url = "https://files.pythonhosted.org/packages/91/e1/583c647404b15f807410510fec1eb9b80cb8474165940b7749f026f21cbc/numba-0.64.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0b180b1133f2b5d8b3f09d96b6d7a9e51a7da5dda3c09e998b5bcfac85d222c", size = 3504309, upload-time = "2026-02-18T18:41:03.252Z" },
-    { url = "https://files.pythonhosted.org/packages/85/23/0fce5789b8a5035e7ace21216a468143f3144e02013252116616c58339aa/numba-0.64.0-cp312-cp312-win_amd64.whl", hash = "sha256:e63dc94023b47894849b8b106db28ccb98b49d5498b98878fac1a38f83ac007a", size = 2752740, upload-time = "2026-02-18T18:41:05.097Z" },
-    { url = "https://files.pythonhosted.org/packages/52/80/2734de90f9300a6e2503b35ee50d9599926b90cbb7ac54f9e40074cd07f1/numba-0.64.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:3bab2c872194dcd985f1153b70782ec0fbbe348fffef340264eacd3a76d59fd6", size = 2683392, upload-time = "2026-02-18T18:41:06.563Z" },
-    { url = "https://files.pythonhosted.org/packages/42/e8/14b5853ebefd5b37723ef365c5318a30ce0702d39057eaa8d7d76392859d/numba-0.64.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:703a246c60832cad231d2e73c1182f25bf3cc8b699759ec8fe58a2dbc689a70c", size = 3812245, upload-time = "2026-02-18T18:41:07.963Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/a2/f60dc6c96d19b7185144265a5fbf01c14993d37ff4cd324b09d0212aa7ce/numba-0.64.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7e2e49a7900ee971d32af7609adc0cfe6aa7477c6f6cccdf6d8138538cf7756f", size = 3511328, upload-time = "2026-02-18T18:41:09.504Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/2a/fe7003ea7e7237ee7014f8eaeeb7b0d228a2db22572ca85bab2648cf52cb/numba-0.64.0-cp313-cp313-win_amd64.whl", hash = "sha256:396f43c3f77e78d7ec84cdfc6b04969c78f8f169351b3c4db814b97e7acf4245", size = 2752668, upload-time = "2026-02-18T18:41:11.455Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/8a/77d26afe0988c592dd97cb8d4e80bfb3dfc7dbdacfca7d74a7c5c81dd8c2/numba-0.64.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:f565d55eaeff382cbc86c63c8c610347453af3d1e7afb2b6569aac1c9b5c93ce", size = 2683590, upload-time = "2026-02-18T18:41:12.897Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/4b/600b8b7cdbc7f9cebee9ea3d13bb70052a79baf28944024ffcb59f0712e3/numba-0.64.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9b55169b18892c783f85e9ad9e6f5297a6d12967e4414e6b71361086025ff0bb", size = 3781163, upload-time = "2026-02-18T18:41:15.377Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/73/53f2d32bfa45b7175e9944f6b816d8c32840178c3eee9325033db5bf838e/numba-0.64.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:196bcafa02c9dd1707e068434f6d5cedde0feb787e3432f7f1f0e993cc336c4c", size = 3481172, upload-time = "2026-02-18T18:41:17.281Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/00/aebd2f7f1e11e38814bb96e95a27580817a7b340608d3ac085fdbab83174/numba-0.64.0-cp314-cp314-win_amd64.whl", hash = "sha256:213e9acbe7f1c05090592e79020315c1749dd52517b90e94c517dca3f014d4a1", size = 2754700, upload-time = "2026-02-18T18:41:19.277Z" },
 ]
 
 [[package]]
@@ -2060,19 +2005,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
-]
-
-[[package]]
-name = "sparse"
-version = "0.18.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numba" },
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/56/64/46da3957f8f9af03179eca946d786c56f22b9458cedf472850e02948a8c1/sparse-0.18.0.tar.gz", hash = "sha256:57f92661eb0ec0c764b450c72f3c0d869ea7f32e5e4ca0a335f9d6a7d79bbff4", size = 791987, upload-time = "2026-02-19T06:17:55.376Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/a9/804ac7423f5dda316d3a982f3ab071c971fb877f8961dad9f6a97d12d2ee/sparse-0.18.0-py2.py3-none-any.whl", hash = "sha256:6f4a127d5aae88eca41ea8106bbd5a7830f83d068b37291df597a43511212069", size = 151931, upload-time = "2026-02-19T06:17:53.11Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This provides implementations of `qp.math.expand_matrix` and `qp.math.expand_vector` that are suited for mixed-dimensional subsystems. These are then used to clean up bosonic qiskit and remove a dependency on `sparse`.