### PR TITLE
Justfile and `docs` test marker

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,12 +1,12 @@
 # SPDX-FileCopyrightText: 2025 Battelle Memorial Institute
 # SPDX-License-Identifier: BSD-2-Clause
 # Based on Sybil documentation: https://sybil.readthedocs.io/en/latest/quickstart.html
-import importlib.util
 from doctest import ELLIPSIS
 from typing import Any
 
 import numpy as np
 import pennylane as qml
+import pytest
 from sybil import Sybil
 from sybil.parsers.rest import DocTestParser, PythonCodeBlockParser
 
@@ -21,13 +21,18 @@ def setup(namespace: dict[str, Any]):
     }
 
 
-# todo: rework doc testing to skip tests involving bosonic qiskit if it's not installed
-if importlib.util.find_spec("bosonic_qiskit") is not None:
-    pytest_collect_file = Sybil(
-        parsers=[
-            DocTestParser(optionflags=ELLIPSIS),
-            PythonCodeBlockParser(),
-        ],
-        patterns=["docs/source/*.rst", "*.py"],
-        setup=setup,
-    ).pytest()
+pytest_collect_file = Sybil(
+    parsers=[
+        DocTestParser(optionflags=ELLIPSIS),
+        PythonCodeBlockParser(),
+    ],
+    patterns=["docs/source/*.rst", "*.py"],
+    setup=setup,
+    name="sybil",
+).pytest()
+
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        if "sybil" in item.nodeid:
+            item.add_marker(pytest.mark.docs)

--- a/justfile
+++ b/justfile
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2025 Battelle Memorial Institute
+# SPDX-License-Identifier: BSD-2-Clause
+
+serve-docs:
+    @uv sync --group docs
+    @cd docs && uv run sphinx-autobuild source _build/html --watch ../src --ignore "source/_autoapi/**/*.rst" --re-ignore ".*__pycache__.*"
+
+build-docs: test-docs
+    @uv sync --group docs
+    @cd docs && uv run make html
+
+test-all:
+    @uv sync --all-extras --all-groups
+    @uv pip install jax torch --torch-backend=cpu
+    @uv run pytest
+
+test-docs:
+    @uv sync --all-extras --all-groups && uv pip install jax torch --torch-backend=cpu
+    @uv run pytest -m "docs"
+
+test-core:
+    @uv sync --all-groups && uv pip install jax
+    @uv run pytest -m "not bq and not slow"

--- a/pytest.toml
+++ b/pytest.toml
@@ -5,6 +5,7 @@ markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "unit: marks tests as unit tests (select with '-m \"unit\"')",
     "integration: marks tests as integration tests (select with '-m \"integration\"')",
+    "docs: marks tests that check documentation (select with '-m \"docs\"')",
     "bq: marks tests that use Bosonic Qiskit (select with '-m \"bq\"')",
     "torch: marks tests that use PyTorch (select with '-m \"torch\"')",
     "jax: marks tests that use JAX (select with '-m \"jax\"')",


### PR DESCRIPTION
- Adds `docs` flag to select tests in documentation generated by Sybil.
- Introduces justfile recipes to improve dev tooling