### PR TITLE
More math operations

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -13,8 +13,10 @@ from sybil.parsers.rest import DocTestParser, PythonCodeBlockParser
 import hybridlane as hqml
 
 try:
+    import jax
     import jax.numpy as jnp
 except ImportError:
+    jax = None
     jnp = None
 
 printoptions = np.get_printoptions()
@@ -23,6 +25,8 @@ printoptions = np.get_printoptions()
 def setup(namespace: dict[str, Any]):
     namespace |= {"qml": qml, "hqml": hqml, "np": np, "jnp": jnp}
     np.set_printoptions(precision=4, suppress=True)
+    if jax:
+        jax.config.update("jax_enable_x64", True)
 
 
 def teardown(namespace: dict[str, Any]):

--- a/justfile
+++ b/justfile
@@ -10,14 +10,17 @@ build-docs: test-docs
     @cd docs && uv run make html
 
 test-all:
-    @uv sync --all-extras --all-groups
-    @uv pip install jax torch --torch-backend=cpu
+    @uv sync --all-extras --all-groups && uv pip install jax torch --torch-backend=cpu
     @uv run pytest
 
 test-docs:
     @uv sync --all-extras --all-groups && uv pip install jax torch --torch-backend=cpu
     @uv run pytest -m "docs"
 
+test-core-tensorlibs:
+    @uv sync --all-groups && uv pip install jax torch --torch-backend=cpu
+    @uv run pytest -m "not (bq or slow or docs)"
+
 test-core:
-    @uv sync --all-groups && uv pip install jax
-    @uv run pytest -m "not bq and not slow and not docs"
+    @uv sync --all-groups
+    @uv run pytest -m "not (bq or slow or docs or jax)"

--- a/pytest.toml
+++ b/pytest.toml
@@ -9,4 +9,5 @@ markers = [
     "bq: marks tests that use Bosonic Qiskit (select with '-m \"bq\"')",
     "torch: marks tests that use PyTorch (select with '-m \"torch\"')",
     "jax: marks tests that use JAX (select with '-m \"jax\"')",
+    "all_interfaces: marks tests that should be run for all interfaces (select with '-m \"all_interfaces\"')",
 ]

--- a/src/hybridlane/math/__init__.py
+++ b/src/hybridlane/math/__init__.py
@@ -7,13 +7,19 @@ from pennylane import math as pl_math
 
 from . import array_manipulation  # noqa: F401
 from .matrix_manipulation import expand_matrix, expand_vector
+from .quantum import reduce_dm, reduce_statevector
 
 dag = ar.dag
 
 
 def __getattr__(name):
-    # Fallback to pennylane math library so that users can just use our version seamlessly
-    return getattr(pl_math, name)
+    import numpy as np
+
+    # This branch stops Sybil/pytest from erroring when looking for "pytest_plugins" or
+    # "__code__"
+    if name in vars(pl_math) or name in dir(np):
+        return getattr(pl_math, name)
+    raise AttributeError(f"module 'hybridlane.math' has no attribute {name!r}")
 
 
 def __dir__():
@@ -22,4 +28,10 @@ def __dir__():
     return list(our_stuff | set(pl_math.__dir__()))
 
 
-__all__ = ["expand_matrix", "expand_vector", "dag"] + pl_math.__all__
+__all__ = [
+    "expand_matrix",
+    "expand_vector",
+    "reduce_dm",
+    "reduce_statevector",
+    "dag",
+] + pl_math.__all__

--- a/src/hybridlane/math/__init__.py
+++ b/src/hybridlane/math/__init__.py
@@ -5,6 +5,7 @@ r"""A wrapper around :mod:`pennylane.math` providing tensor-library agnostic fun
 import autoray as ar
 from pennylane import math as pl_math
 
+from . import array_manipulation  # noqa: F401
 from .matrix_manipulation import expand_matrix, expand_vector
 
 dag = ar.dag
@@ -17,7 +18,7 @@ def __getattr__(name):
 
 def __dir__():
     # Include the functions from pennylane math library in the dir() output
-    our_stuff = set(list(globals().keys())) - {"pl_math", "ar"}
+    our_stuff = set(list(globals().keys())) - {"pl_math", "ar", "array_manipulation"}
     return list(our_stuff | set(pl_math.__dir__()))
 
 

--- a/src/hybridlane/math/array_manipulation.py
+++ b/src/hybridlane/math/array_manipulation.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 Battelle Memorial Institute
+# SPDX-License-Identifier: BSD-2-Clause
+import autoray as ar
+
+
+def numpy_unstack(arr, axis=0):
+    import numpy as np
+
+    return np.unstack(arr, axis=axis)
+
+
+def jax_unstack(arr, axis=0):
+    import jax.numpy as jnp
+
+    return jnp.unstack(arr, axis=axis)
+
+
+def torch_unstack(arr, axis=0):
+    import torch
+
+    return torch.unbind(arr, dim=axis)
+
+
+ar.register_function("numpy", "unstack", numpy_unstack)
+ar.register_function("jax", "unstack", jax_unstack)
+ar.register_function("torch", "unstack", torch_unstack)

--- a/src/hybridlane/math/matrix_manipulation.py
+++ b/src/hybridlane/math/matrix_manipulation.py
@@ -281,7 +281,7 @@ def expand_vector(
     in through the ``wire_dims`` argument. If not specified, it defaults to 2 for all wires, which is the behavior of PennyLane.
 
     Args:
-        vec: The vector to expand. Must be square and have shape ``(d,)`` where ``d`` is
+        vec: The vector to expand. Must have shape ``(d,)`` where ``d`` is
             the composite dimension of the wires in ``wires``. Can also have a batch dimension.
 
         wires: The wires that the matrix acts on.

--- a/src/hybridlane/math/quantum.py
+++ b/src/hybridlane/math/quantum.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: 2025 Battelle Memorial Institute
+# SPDX-License-Identifier: BSD-2-Clause
+import itertools
+from collections.abc import Sequence
+from string import ascii_lowercase as alphabet
+
+from pennylane import math
+from pennylane.typing import TensorLike
+
+
+def reduce_statevector(
+    state: TensorLike,
+    indices: Sequence[int],
+    dims: Sequence[int],
+    c_dtype: str = "complex128",
+) -> TensorLike:
+    r"""Reduces a statevector to a density matrix by tracing out the subsystems
+
+    Args:
+        state: The statevector to be reduced. Shape (..., d) where d is the product of the
+            dimensions in ``dims``.
+
+        indices: The indices of the subsystems to keep
+
+        dims: The dimensions of the subsystems. The length of this sequence should match the
+            number of subsystems in the statevector, and the product of the dimensions should
+            match the last dimension of ``state``.
+
+        c_dtype: The complex dtype to use for the output density matrix.
+
+    Returns:
+        The reduced density matrix. Shape ``(..., d_out, d_out)`` where d_out is the product
+        of the dimensions of the subsystems in ``indices``.
+
+    **Examples**
+
+    >>> state = np.array([1, 0, 1, 0]) / np.sqrt(2)
+    >>> reduce_statevector(state, indices=[0], dims=[2, 2])
+    array([[0.5+0.j, 0.5+0.j],
+           [0.5+0.j, 0.5+0.j]])
+
+    >>> reduce_statevector(state, indices=[1], dims=[2, 2])
+    array([[1.+0.j, 0.+0.j],
+           [0.+0.j, 0.+0.j]])
+
+    >>> state = hqml.math.kron([1, 0], [0, 1, 0])
+    >>> reduce_statevector(state, indices=[0], dims=[2, 3])
+    array([[1.+0.j, 0.+0.j],
+           [0.+0.j, 0.+0.j]])
+
+    >>> state = jnp.array(state)
+    >>> reduce_statevector(state, indices=[1], dims=[2, 3])
+    Array([[0.+0.j, 0.+0.j, 0.+0.j],
+           [0.+0.j, 1.+0.j, 0.+0.j],
+           [0.+0.j, 0.+0.j, 0.+0.j]], dtype=complex128)
+
+    .. seealso:: :func:`~hybridlane.math.reduce_dm`
+    """
+    n_input = len(dims)
+    d = int(math.prod(dims))
+
+    # Reshape the statevector from (..., d) to (..., d1, d2, ..., dn)
+    inner_shape = tuple(dims[i] for i in range(n_input))
+    batch_size = math.get_batch_size(state, (d,), d)
+    shape = (batch_size, *inner_shape) if batch_size else inner_shape
+    state = math.reshape(state, shape)
+    state = math.cast(state, c_dtype)
+
+    # Construct matching indices that look like ...abcd
+    indices0 = alphabet[:n_input]
+    indices1 = alphabet[:n_input]
+
+    # Now for each index we'd like to keep, assign a new unique letter
+    #
+    # e.g. if n_input=4 and indices=[0, 2], we should end up with
+    #
+    #   ...abcd,...ebfd->...aecf
+    for i in indices:
+        indices1 = indices1.replace(indices1[i], alphabet[n_input + i])
+
+    # Interleave the kept indices to get the output
+    out_indices = "".join(
+        itertools.chain(
+            *zip(
+                [indices0[i] for i in indices],
+                [indices1[i] for i in indices],
+            )
+        )
+    )
+
+    einsum_str = f"...{indices0},...{indices1}->...{out_indices}"
+    rho = math.einsum(einsum_str, state, math.conj(state))
+
+    # Finally reshape our density matrix to shape (..., d_out, d_out)
+    d_out = int(math.prod([dims[i] for i in indices]))
+    shape = (batch_size, d_out, d_out) if batch_size else (d_out, d_out)
+    return math.reshape(rho, shape)
+
+
+def reduce_dm(
+    rho: TensorLike,
+    indices: Sequence[int],
+    dims: Sequence[int],
+    c_dtype: str = "complex128",
+) -> TensorLike:
+    r"""Reduces the dimension of a density matrix by tracing out the subsystems
+
+    Args:
+        rho: The density matrix to be reduced. Shape ``(..., d, d)`` where d is the product
+            of the dimensions in ``dims``.
+
+        indices: The indices of the subsystems to keep
+
+        dims: The dimensions of the subsystems. The length of this sequence should match the
+            number of subsystems in ``rho``, and the product of the dimensions should
+            match the last dimension of ``rho``.
+
+        c_dtype: The complex dtype to use for the output density matrix.
+
+    Returns:
+        The reduced density matrix. Shape ``(..., d_out, d_out)`` where d_out is the product
+        of the dimensions of the subsystems in ``indices``.
+
+    **Examples**
+
+    >>> rho = [[0.5, 0, 0.5, 0], [0, 0, 0, 0], [0.5, 0, 0.5, 0], [0, 0, 0, 0]]
+    >>> reduce_dm(rho, indices=[0], dims=[2, 2])
+    array([[0.5+0.j, 0.5+0.j],
+           [0.5+0.j, 0.5+0.j]])
+
+    >>> rho = jnp.array(rho)
+    >>> reduce_dm(rho, indices=[1], dims=[2, 2])
+    Array([[1.+0.j, 0.+0.j],
+           [0.+0.j, 0.+0.j]], dtype=complex128)
+
+    .. seealso:: :func:`~hybridlane.math.reduce_statevector`
+    """
+
+    n_input = len(dims)
+    d = int(math.prod(dims))
+
+    # Reshape from (..., d, d) to (..., d1, d2, ..., dn, d1', d2', ..., dn')
+    inner_shape = tuple(dims) * 2
+    batch_size = math.get_batch_size(rho, (d, d), d**2)
+    shape = (batch_size, *inner_shape) if batch_size else inner_shape
+    rho = math.reshape(rho, shape)
+    rho = math.cast(rho, c_dtype)
+
+    # Construct matching indices that look like ...abcd
+    indices0 = alphabet[:n_input]
+    indices1 = alphabet[:n_input]
+
+    # Now for each index we'd like to keep, assign a new unique letter
+    #
+    # e.g. if n_input=4 and indices=[0, 2], we should end up with
+    #
+    #   ...abcd,...ebfd->...aecf
+    for i in indices:
+        indices1 = indices1.replace(indices1[i], alphabet[n_input + i])
+
+    # Interleave the kept indices to get the output
+    out_indices = "".join(
+        itertools.chain(
+            *zip(
+                [indices0[i] for i in indices],
+                [indices1[i] for i in indices],
+            )
+        )
+    )
+
+    einsum_str = f"...{indices0}{indices1}->...{out_indices}"
+    rho_reduced = math.einsum(einsum_str, rho)
+
+    # Reshape to (..., d_out, d_out)
+    d_out = int(math.prod([dims[i] for i in indices]))
+    shape = (batch_size, d_out, d_out) if batch_size else (d_out, d_out)
+    return math.reshape(rho_reduced, shape)

--- a/src/hybridlane/ops/mixins.py
+++ b/src/hybridlane/ops/mixins.py
@@ -176,7 +176,7 @@ class FockRepresentation:
                [0.    +0.j    , 0.    +0.j    , 0.    +0.j    , 0.    -0.j    ,
                 0.9689+0.2474j, 0.    -0.j    ],
                [0.    +0.j    , 0.    +0.j    , 0.    +0.j    , 0.    -0.j    ,
-                0.    -0.j    , 0.8776+0.4794j]], dtype=complex64)
+                0.    -0.j    , 0.8776+0.4794j]], dtype=complex128)
 
         Args:
             wire_dims: The dimension of each wire in the order of ``self.wires``
@@ -263,7 +263,7 @@ class FockRepresentation:
         >>> hqml.R(jnp.array(0.123), wires=0).fock_matrix({0: 3})
         Array([[1.    +0.j    , 0.    +0.j    , 0.    +0.j    ],
                [0.    +0.j    , 0.9924-0.1227j, 0.    +0.j    ],
-               [0.    +0.j    , 0.    +0.j    , 0.9699-0.2435j]],      dtype=complex64, weak_type=True)
+               [0.    +0.j    , 0.    +0.j    , 0.9699-0.2435j]],      dtype=complex128, weak_type=True)
 
         Developers of new gates should prefer to implement ``compute_fock_matrix``.
         """

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -33,6 +33,15 @@ def disable_graph_decomp():
 
 
 def pytest_collection_modifyitems(config, items):
+    for item in items:
+        # Check if this is a parametrized test with 'like' parameter
+        if hasattr(item, "callspec") and "like" in item.callspec.params:
+            like_value = item.callspec.params["like"]
+            if like_value == "jax":
+                item.add_marker(pytest.mark.jax)
+            elif like_value == "torch":
+                item.add_marker(pytest.mark.torch)
+
     if importlib.util.find_spec("jax") is None:
         skip_jax = pytest.mark.skip(reason="jax not installed")
         for item in items:
@@ -50,3 +59,11 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "bq" in item.keywords:
                 item.add_marker(skip_bq)
+
+
+def pytest_generate_tests(metafunc):
+    # Hook to parametrize tests over deep learning interfaces
+    if metafunc.definition.get_closest_marker("all_interfaces"):
+        if "like" in metafunc.fixturenames:
+            like_values = ["numpy", "jax"]
+            metafunc.parametrize("like", like_values)

--- a/test/math/test_quantum.py
+++ b/test/math/test_quantum.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: 2025 Battelle Memorial Institute
+# SPDX-License-Identifier: BSD-2-Clause
+import pennylane as qp
+import pytest
+
+from hybridlane import math
+
+
+class TestReduceStatevector:
+    @pytest.mark.parametrize("dtype", ["complex64", "complex128"])
+    @pytest.mark.all_interfaces
+    def test_qubit_states(self, like, dtype):
+        def f(state, indices, dims):
+            return math.reduce_statevector(state, indices, dims, c_dtype=dtype)
+
+        if like == "jax":
+            import jax
+
+            f = jax.jit(f, static_argnums=(1, 2))
+
+        states = [
+            math.array([1, 0, 0, 0], like=like),
+            math.array([1, 0, 1, 0], like=like) / math.sqrt(2),
+            math.array([1, 0, 0, 1], like=like) / math.sqrt(2),
+        ]
+
+        for state in states:
+            for index in (0, 1):
+                expected = qp.math.reduce_statevector(
+                    state, indices=(index,), c_dtype=dtype
+                )
+                actual = f(state, indices=(index,), dims=(2, 2))
+                assert math.get_dtype_name(actual) == dtype
+                assert actual == pytest.approx(expected)
+
+    @pytest.mark.all_interfaces
+    def test_cv_states(self, like):
+        def f(state, indices, dims):
+            return math.reduce_statevector(state, indices, dims)
+
+        if like == "jax":
+            import jax
+
+            f = jax.jit(f, static_argnums=(1, 2))
+
+        state0 = math.array([0, 1, 0], like=like)
+        state1 = math.array([1, 0], like=like)
+        state = math.kron(state0, state1)
+
+        expected = math.outer(state0, state0)
+        actual = f(state, indices=(0,), dims=(3, 2))
+        assert str(actual.dtype) == "complex128"
+        assert actual == pytest.approx(expected)
+
+        expected = math.outer(state1, state1)
+        actual = f(state, indices=(1,), dims=(3, 2))
+        assert str(actual.dtype) == "complex128"
+        assert actual == pytest.approx(expected)
+
+
+class TestReduceDensityMatrix:
+    @pytest.mark.parametrize("dtype", ["complex64", "complex128"])
+    @pytest.mark.all_interfaces
+    def test_qubit_states(self, like, dtype):
+        def f(state, indices, dims):
+            return math.reduce_dm(state, indices, dims, c_dtype=dtype)
+
+        if like == "jax":
+            import jax
+
+            f = jax.jit(f, static_argnums=(1, 2))
+
+        states = [
+            math.array(
+                [[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]], like=like
+            ),
+            math.array(
+                [[0.5, 0, 0.5, 0], [0, 0, 0, 0], [0.5, 0, 0.5, 0], [0, 0, 0, 0]],
+                like=like,
+            ),
+            math.array(
+                [
+                    [[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]],
+                    [[0, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]],
+                ],
+                like=like,
+            ),
+        ]
+
+        for state in states:
+            for index in (0, 1):
+                expected = qp.math.reduce_dm(state, indices=(index,), c_dtype=dtype)
+                actual = f(state, indices=(index,), dims=(2, 2))
+                assert math.get_dtype_name(actual) == dtype
+                assert actual == pytest.approx(expected)
+
+    @pytest.mark.all_interfaces
+    def test_cv_states(self, like):
+        def f(state, indices, dims):
+            return math.reduce_dm(state, indices, dims)
+
+        if like == "jax":
+            import jax
+
+            f = jax.jit(f, static_argnums=(1, 2))
+
+        state0 = math.array([0, 1, 0], like=like)
+        state1 = math.array([1, 0], like=like)
+        state = math.kron(state0, state1)
+        rho = math.outer(state, state)
+
+        expected = math.outer(state0, state0)
+        actual = f(rho, indices=(0,), dims=(3, 2))
+        assert str(actual.dtype) == "complex128"
+        assert actual == pytest.approx(expected)
+
+        expected = math.outer(state1, state1)
+        actual = f(rho, indices=(1,), dims=(3, 2))
+        assert str(actual.dtype) == "complex128"
+        assert actual == pytest.approx(expected)


### PR DESCRIPTION
- Registers autoray implementations of `np.unstack` for NumPy, Torch, and JAX
- Introduces analogous operations for `qp.math.reduce_dm` and `qp.math.reduce_statevector`, each handling heterogenous system sizes
- Simplifies testing with `@pytest.mark.all_interfaces` marker and improved justfile