### PR TITLE
Fix hl.sample to pass original tape wires

### DIFF
--- a/src/hybridlane/devices/default_hybrid/device.py
+++ b/src/hybridlane/devices/default_hybrid/device.py
@@ -504,6 +504,7 @@ class DefaultHybrid(Device):
         self._prng_key, *prng_keys = jax_random_split(self._prng_key, len(circuits) + 1)
 
         # Get the concrete wire_dims by performing type inference
+        wire_maps = list(map(lambda t: t._get_standard_wire_map(), circuits))
         wire_dims = list(map(lambda t: _get_wire_dims(t, execution_config), circuits))
         remapped_circuits = map(QuantumScript.map_to_standard_wires, circuits)
 
@@ -514,8 +515,9 @@ class DefaultHybrid(Device):
                     "prng_key": prng_key,
                     "interface": execution_config.interface,
                     "debugger": self._debugger,
+                    "wire_map": wire_map,
                 }
-                for prng_key in prng_keys
+                for prng_key, wire_map in zip(prng_keys, wire_maps)
             )
             return tuple(starmap(_simulator, zip(remapped_circuits, wire_dims, kwargs)))
 
@@ -529,8 +531,9 @@ class DefaultHybrid(Device):
                 "prng_key": prng_key,
                 "interface": execution_config.interface,
                 "debugger": self._debugger,
+                "wire_map": wire_map,
             }
-            for rng, prng_key in zip(rngs, prng_keys)
+            for rng, prng_key, wire_map in zip(rngs, prng_keys, wire_maps)
         )
 
         assert execution_config.executor_backend is not None

--- a/src/hybridlane/devices/default_hybrid/sampled.py
+++ b/src/hybridlane/devices/default_hybrid/sampled.py
@@ -20,6 +20,7 @@ from hybridlane.measurements import (
     ExpectationMP,
     ProbabilityMP,
     SampleMeasurement,
+    SampleMP,
     SampleResult,
 )
 
@@ -36,6 +37,7 @@ def measure_with_shots(
     is_state_batched: bool,
     rng: Any | None = None,
     prng_key: "Array | None" = None,
+    wire_map: dict | None = None,
     mid_measurements: dict | None = None,
 ) -> list[TensorLike]:
 
@@ -49,7 +51,15 @@ def measure_with_shots(
 
         prng_key, key = jax_random_split(prng_key)
         results.extend(
-            measurement_func(mp, state, shots, is_state_batched, rng=rng, prng_key=key)  # ty:ignore[invalid-argument-type]
+            measurement_func(
+                mp,
+                state,
+                shots,
+                is_state_batched,
+                rng=rng,
+                prng_key=key,
+                wire_map=wire_map,
+            )  # ty:ignore[invalid-argument-type]
         )
 
     return results
@@ -62,6 +72,7 @@ def measure_with_diagonalizing_gates(
     is_state_batched: bool,
     rng: Any | None = None,
     prng_key: "Array | None" = None,
+    wire_map: dict | None = None,
 ) -> list[TensorLike]:
     num_wires = math.ndim(state) - is_state_batched
     wire_order = Wires(range(num_wires))
@@ -77,7 +88,22 @@ def measure_with_diagonalizing_gates(
         for w, arr in zip(mp.wires, math.unstack(basis_states, axis=-1))
     }
     result = SampleResult.from_basis_states(data)
-    return [mp.process_samples(result, wire_order)]
+    result = mp.process_samples(result, wire_order)
+
+    # Sampling wires, remap to original circuit wire labels
+    if isinstance(mp, SampleMP) and mp.obs is None:
+        if wire_map is not None:
+            rev_wire_map = {v: k for k, v in wire_map.items()}
+            new_data = {rev_wire_map.get(w, w): arr for w, arr in result.data.items()}
+            new_schema = BasisSchema(
+                {
+                    rev_wire_map.get(w, w): result.schema.get_basis(w)
+                    for w in result.schema.wires
+                }
+            )
+            result = SampleResult(schema=new_schema, data=new_data)
+
+    return [result]  # ty:ignore[invalid-return-type]
 
 
 def measure_hamiltonian(
@@ -87,6 +113,7 @@ def measure_hamiltonian(
     is_state_batched: bool,
     rng: Any | None = None,
     prng_key: "Array | None" = None,
+    wire_map: dict | None = None,
 ) -> list[TensorLike]:
     obs = mp.obs
     assert isinstance(obs, (Sum, LinearCombination))

--- a/src/hybridlane/devices/default_hybrid/simulate.py
+++ b/src/hybridlane/devices/default_hybrid/simulate.py
@@ -85,6 +85,7 @@ def measure_final_state(
     debugger=None,
     rng: Any | None = None,
     prng_key: "Array | None" = None,
+    wire_map: dict[Any, Any] | None = None,
     **execution_kwargs,
 ) -> Result:
     if not tape.shots:
@@ -104,6 +105,7 @@ def measure_final_state(
         is_state_batched,
         rng=rng,
         prng_key=prng_key,
+        wire_map=wire_map,
     )
 
     if len(tape.measurements) == 1:

--- a/test/devices/default_hybrid/test_example_circuits.py
+++ b/test/devices/default_hybrid/test_example_circuits.py
@@ -4,6 +4,7 @@ import jax
 import numpy as np
 import pennylane as qp
 import pytest
+from pennylane.wires import Wires
 
 import hybridlane as hl
 from hybridlane.devices.default_hybrid.state_prep import coherent_state
@@ -343,3 +344,29 @@ class TestFiniteCircuits:
         assert hl.math.get_dtype_name(expval) == "float64"
         assert expval.shape == ()
         expval == pytest.approx(0.1 * lam, abs=0.1)
+
+    def test_sample_preserves_wire_labels(self, like):
+        fock_levels = 32
+
+        dev = qp.device("default.hybrid", fock_level=fock_levels, seed=42)
+
+        @qp.set_shots(10)
+        @qp.qnode(dev, interface=like)
+        def circuit():
+            qp.FockState(4, "b")
+            qp.X("a")
+
+            schema = BasisSchema({Wires(["a", "b"]): ComputationalBasis.Discrete})
+            return hl.sample(schema=schema)
+
+        if like == "jax":
+            pytest.xfail(reason="JAX jit doesn't work with sample yet")
+
+        result = circuit()
+
+        assert isinstance(result, SampleResult)
+        assert hl.math.get_deep_interface(result.data) == like
+        assert set(result.data.keys()) == {"a", "b"}
+
+        assert result.data["a"] == pytest.approx(1)
+        assert result.data["b"] == pytest.approx(4)


### PR DESCRIPTION
Fixes hl.sample in the `default.hybrid` device to remap the wire labels back to the original tape wire labels in the event that the user specified non-standard wire labels
