### PR TITLE
Pass kwargs when drawing callable circuit

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -24,12 +24,12 @@ jobs:
 
             - name: Install dependencies with uv
               run: |
-                  uv sync --all-extras --frozen && uv pip install jax torch --torch-backend=cpu
+                  uv sync --all-extras --frozen
 
             - name: Run core tests
               run: |
-                  uv run pytest -m "not bq and not docs"
-          
+                  uv run pytest -m "not (bq or docs or slow)"
+
             - name: Run non-core tests
               run: |
-                  uv run pytest -m "bq or docs"
+                  uv run pytest -m "bq or docs or slow"

--- a/docs/releases/changelog-0.8.0.md
+++ b/docs/releases/changelog-0.8.0.md
@@ -225,6 +225,8 @@
 
 - Fixed the `fock_spectrum` function for `hl.FockStateProjector` (#55)
 
+- `wire_icon_colors` keyword argument is now properly passed down when calling `hl.draw_mpl` on a non-QNode callable (#72)
+
 ### Miscellaneous
 
 - Added a `justfile` to facilitate running common developer tasks (#42)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,14 @@ build-backend = "uv_build"
 
 [dependency-groups]
 dev = [
+    "jax>=0.10.1",
+    "matplotlib>=3.10.9",
+    "openqasm3[parser]>=1.0.1",
+    "optax>=0.2.8",
+    "pytest>=8.4.1",
+    "pytest-cov>=6.2.1",
     "ruff>=0.12.0",
+    "sybil[pytest]>=9.3.0",
     "ty>=0.0.39",
 ]
 docs = [
@@ -66,13 +73,4 @@ docs = [
     "sphinx-copybutton>=0.5.2",
     "sphinx-math-dollar>=1.2.1",
     "sphinxcontrib-bibtex>=2.6.5",
-]
-test = [
-    "jax>=0.10.1",
-    "matplotlib>=3.10.9",
-    "openqasm3[parser]>=1.0.1",
-    "optax>=0.2.8",
-    "pytest>=8.4.1",
-    "pytest-cov>=6.2.1",
-    "sybil[pytest]>=9.3.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,13 +55,7 @@ build-backend = "uv_build"
 
 [dependency-groups]
 dev = [
-    "jax>=0.10.1",
-    "openqasm3[parser]>=1.0.1",
-    "optax>=0.2.8",
-    "pytest>=8.4.1",
-    "pytest-cov>=6.2.1",
     "ruff>=0.12.0",
-    "sybil[pytest]>=9.3.0",
     "ty>=0.0.39",
 ]
 docs = [
@@ -72,4 +66,13 @@ docs = [
     "sphinx-copybutton>=0.5.2",
     "sphinx-math-dollar>=1.2.1",
     "sphinxcontrib-bibtex>=2.6.5",
+]
+test = [
+    "jax>=0.10.1",
+    "matplotlib>=3.10.9",
+    "openqasm3[parser]>=1.0.1",
+    "optax>=0.2.8",
+    "pytest>=8.4.1",
+    "pytest-cov>=6.2.1",
+    "sybil[pytest]>=9.3.0",
 ]

--- a/src/hybridlane/drawer/draw.py
+++ b/src/hybridlane/drawer/draw.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from functools import wraps
+from functools import partial, wraps
 from typing import TYPE_CHECKING, Callable, Literal
 from unittest.mock import patch
 
@@ -26,10 +26,7 @@ def draw_mpl(
     *,
     max_length: int | None = None,
     fig=None,
-    level: Literal["top", "user", "device", "gradient"]
-    | int
-    | slice
-    | None = "gradient",
+    level: Literal["top", "user", "device", "gradient"] | int | slice = "gradient",
     **kwargs,
 ):
     r"""Draws a circuit using matplotlib
@@ -49,8 +46,8 @@ def draw_mpl(
         style: The drawing style to use. See :py:func:`qp.draw_mpl <pennylane.draw_mpl>`.
 
     Keyword Args:
-        wire_icon_colors (dict): A dictionary mapping wires to optional matplotlib-compatible colors.
-            All wires that aren't provided will use default qubit or qumode colors.
+        wire_icon_colors (dict): A dictionary mapping wires to optional matplotlib-compatible
+            colors. All wires that aren't provided will use default qubit or qumode colors.
 
     For other arguments, see :py:func:`qp.draw_mpl <pennylane.draw_mpl>`.
 
@@ -78,8 +75,9 @@ def draw_mpl(
 
     .. figure:: ../../_static/draw_mpl/ex_jc_circuit.png
 
-    Furthermore, icon colors can be adjusted from their defaults (say to color different motional modes of an ion trap). Note
-    that Hybridlane also has a special notation for "qubit-conditioned" gates.
+    Furthermore, icon colors can be adjusted from their defaults (say to color different motional
+    modes of an ion trap). Note that Hybridlane also has a special notation for
+    "qubit-conditioned" gates like :math:`CD`.
 
     .. code-block:: python
 
@@ -126,12 +124,22 @@ def draw_mpl(
 
     @wraps(qnode)
     def wrapper(*args, **kwargs_qnode):
-        with patch("pennylane.drawer.draw.tape_mpl", tape_mpl):
+        # By applying the custom kwargs here for hybridlane, we ensure they'll reach tape_mpl.
+        # Otherwise, particularly when calling draw_mpl on regular non-QNode funcs, PL internally
+        # drops the kwargs and we can't rely on them to reach our tape_mpl. This is a bit of a
+        # hack, and long term we should redo the drawing mechanism
+        wire_icon_colors = kwargs.pop("wire_icon_colors", None)
+        patched_fn = partial(
+            tape_mpl,
+            wire_icon_colors=wire_icon_colors,
+            show_wire_types=show_wire_types,
+        )
+
+        with patch("pennylane.drawer.draw.tape_mpl", patched_fn):
             orig_wrapper = qp.draw_mpl(
                 qnode,
                 wire_order=wire_order,
                 show_all_wires=show_all_wires,
-                show_wire_types=show_wire_types,
                 decimals=decimals,
                 style=style,
                 max_length=max_length,

--- a/src/hybridlane/drawer/mpldrawer.py
+++ b/src/hybridlane/drawer/mpldrawer.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import warnings
-from typing import Literal
 
 import matplotlib.colors as mc
 import numpy as np
@@ -10,6 +9,8 @@ from matplotlib import patches
 from matplotlib import pyplot as plt
 from numpy.polynomial import Polynomial
 from pennylane.drawer.mpldrawer import MPLDrawer, _to_tuple
+
+from ..wires import Qubit, Qudit, Qumode, WireType
 
 
 class HybridMPLDrawer(MPLDrawer):
@@ -25,9 +26,7 @@ class HybridMPLDrawer(MPLDrawer):
         # Store instances so we can retrieve them in _draw_icons
         self._instances.append(self)
 
-    def wire_icons(
-        self, icons: list[Literal["qumode", "qubit"]], colors: list | None = None
-    ):
+    def wire_icons(self, icons: list[WireType], colors: list | None = None):
         # Shift the left side over to make room for the icons
         left = self._ax.get_xlim()[0]
         left -= self._icon_width + 0.25  # extra padding
@@ -37,16 +36,16 @@ class HybridMPLDrawer(MPLDrawer):
 
         colors = colors or [plt.rcParams["lines.color"]] * len(icons)
         for wire, (icon, color) in enumerate(zip(icons, colors)):
-            if icon not in ("qumode", "qubit"):
-                raise ValueError(f"Unknown icon type {icon}")
-
             options = {"color": color}
 
             match icon:
-                case "qumode":
+                case Qumode():
                     self._qumode_icon(icon_x, wire, options=options)
-                case "qubit":
+                case Qubit():
                     self._qubit_icon(icon_x, wire, options=options)
+                # todo: support drawing qudits
+                case Qudit():  # pragma: no cover
+                    raise NotImplementedError("Drawing qudits is not yet supported")
 
     def _qumode_icon(self, icon_x, wire, options: dict | None = None):
         # For a parabola with the icon centered at x0, y0, and width w, h, we have
@@ -115,16 +114,12 @@ class HybridMPLDrawer(MPLDrawer):
         plt.plot([x - w / 2, x + w / 2], [y - r / 3, y - r / 3], color=color)
         plt.plot([x - w / 2, x + w / 2], [y + r / 3, y + r / 3], color=color)
 
-    def z_conditional(
-        self, layer, wires, wires_target=None, control_values=None, options=None
-    ):
+    def z_conditional(self, layer, wires, wires_target=None, options=None):
         if options is None:
             options = {}
 
         wires_ctrl = _to_tuple(wires)
         wires_target = _to_tuple(wires_target)
-        if control_values is not None:
-            control_values = _to_tuple(control_values)
 
         wires_all = wires_ctrl + wires_target
         min_wire = min(wires_all)
@@ -142,17 +137,8 @@ class HybridMPLDrawer(MPLDrawer):
         line = plt.Line2D((layer, layer), (min_wire, max_wire), **options)
         self._ax.add_line(line)
 
-        if control_values is None:
-            for wire in wires_ctrl:
-                self._cond_diamond(layer, wire, options=options)
-        else:
-            if len(control_values) != len(wires_ctrl):
-                raise ValueError("`control_values` must be the same length as `wires`")
-            for wire, control_on in zip(wires_ctrl, control_values):
-                if control_on:
-                    self._cond_diamond(layer, wire, options=options)
-                else:
-                    self._condo_diamond(layer, wire, options=options)
+        for wire in wires_ctrl:
+            self._cond_diamond(layer, wire, options=options)
 
     def _cond_diamond(self, layer, wires, options=None):
         if options is None:
@@ -166,38 +152,6 @@ class HybridMPLDrawer(MPLDrawer):
             (layer, wires), 4, radius=self._ctrl_rad, orientation=0, **options
         )
         self._ax.add_patch(poly)
-
-    def _condo_diamond(self, layer, wires, options=None):
-        new_options = _open_diamond_options_process(options)
-
-        poly = patches.RegularPolygon(
-            (layer, wires),
-            4,
-            radius=self._ctrl_rad,
-            orientation=0,
-            **new_options,
-        )
-        self._ax.add_patch(poly)
-
-
-def _open_diamond_options_process(options):
-    options = options or {}
-
-    new_options = options.copy()
-    if "color" in new_options:
-        new_options["facecolor"] = plt.rcParams["axes.facecolor"]
-        new_options["edgecolor"] = options["color"]
-        new_options["color"] = None
-    else:
-        new_options["edgecolor"] = plt.rcParams["lines.color"]
-        new_options["facecolor"] = plt.rcParams["axes.facecolor"]
-
-    if "linewidth" not in new_options:
-        new_options["linewidth"] = plt.rcParams["lines.linewidth"]
-    if "zorder" not in new_options:
-        new_options["zorder"] = 3
-
-    return new_options
 
 
 def _parabola_width(poly: Polynomial, y: float):

--- a/src/hybridlane/drawer/tape_mpl.py
+++ b/src/hybridlane/drawer/tape_mpl.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import patch
 
 from pennylane.drawer import tape_mpl as pl_tape_mpl
@@ -24,83 +24,79 @@ try:
     import matplotlib as mpl
 
     from .mpldrawer import HybridMPLDrawer
-except (ModuleNotFoundError, ImportError):
+except (ModuleNotFoundError, ImportError):  # pragma: no cover
     has_mpl = False
-    HybridMPLDrawer = object
+    HybridMPLDrawer = object  # ty:ignore[invalid-assignment]
 
 default_qumode_color = "mediumseagreen"
 default_qubit_color = "darkorchid"
 
+if TYPE_CHECKING:
+    import matplotlib as mpl
+    import matplotlib.figure
+
 
 # Register our custom gates
-# Todo: Maybe we should create a symbolicop for "conditional", not the mcm conditional
+# todo: Maybe we should create a symbolicop for "conditional", not the mcm conditional
 # but another kind that acts similarly to conditional displacement
 @_add_operation_to_drawer.register
-def _(op: ops.ConditionalDisplacement, drawer: HybridMPLDrawer, layer: int, _config):
+def _(op: ops.CD, drawer: HybridMPLDrawer, layer: int, _config):
     qubit, qumode = op.wires.tolist()
-    drawer.z_conditional(layer, [qubit], wires_target=qumode, control_values=[True])
+    drawer.z_conditional(layer, [qubit], wires_target=qumode)
 
     new_op = ops.Displacement(*op.parameters, wires=qumode)
     _add_operation_to_drawer(new_op, drawer, layer, _config)
 
 
 @_add_operation_to_drawer.register
-def _(op: ops.ConditionalParity, drawer: HybridMPLDrawer, layer: int, _config):
+def _(op: ops.CP, drawer: HybridMPLDrawer, layer: int, _config):
     qubit, qumode = op.wires.tolist()
-    drawer.z_conditional(layer, [qubit], wires_target=qumode, control_values=[True])
+    drawer.z_conditional(layer, [qubit], wires_target=qumode)
 
     new_op = ops.Fourier(wires=qumode)
     _add_operation_to_drawer(new_op, drawer, layer, _config)
 
 
 @_add_operation_to_drawer.register
-def _(op: ops.ConditionalRotation, drawer: HybridMPLDrawer, layer: int, _config):
+def _(op: ops.CR, drawer: HybridMPLDrawer, layer: int, _config):
     qubit, qumode = op.wires.tolist()
-    drawer.z_conditional(layer, [qubit], wires_target=qumode, control_values=[True])
+    drawer.z_conditional(layer, [qubit], wires_target=qumode)
 
     new_op = ops.Rotation(*op.parameters, wires=qumode)
     _add_operation_to_drawer(new_op, drawer, layer, _config)
 
 
 @_add_operation_to_drawer.register
-def _(op: ops.ConditionalSqueezing, drawer: HybridMPLDrawer, layer: int, _config):
+def _(op: ops.CS, drawer: HybridMPLDrawer, layer: int, _config):
     qubit, qumode = op.wires.tolist()
-    drawer.z_conditional(layer, [qubit], wires_target=qumode, control_values=[True])
+    drawer.z_conditional(layer, [qubit], wires_target=qumode)
 
     new_op = ops.Squeezing(*op.parameters, wires=qumode)
     _add_operation_to_drawer(new_op, drawer, layer, _config)
 
 
 @_add_operation_to_drawer.register
-def _(op: ops.ConditionalBeamsplitter, drawer: HybridMPLDrawer, layer: int, _config):
+def _(op: ops.CBS, drawer: HybridMPLDrawer, layer: int, _config):
     qubit, *qumodes = op.wires.tolist()
-    drawer.z_conditional(
-        layer, [qubit], wires_target=min(qumodes), control_values=[True]
-    )
+    drawer.z_conditional(layer, [qubit], wires_target=qumodes)
 
     new_op = ops.Beamsplitter(*op.parameters, wires=qumodes)
     _add_operation_to_drawer(new_op, drawer, layer, _config)
 
 
 @_add_operation_to_drawer.register
-def _(
-    op: ops.ConditionalTwoModeSqueezing, drawer: HybridMPLDrawer, layer: int, _config
-):
+def _(op: ops.CTMS, drawer: HybridMPLDrawer, layer: int, _config):
     qubit, *qumodes = op.wires.tolist()
-    drawer.z_conditional(
-        layer, [qubit], wires_target=min(qumodes), control_values=[True]
-    )
+    drawer.z_conditional(layer, [qubit], wires_target=qumodes)
 
     new_op = ops.TwoModeSqueezing(*op.parameters, wires=qumodes)
     _add_operation_to_drawer(new_op, drawer, layer, _config)
 
 
 @_add_operation_to_drawer.register
-def _(op: ops.ConditionalTwoModeSum, drawer: HybridMPLDrawer, layer: int, _config):
+def _(op: ops.CSUM, drawer: HybridMPLDrawer, layer: int, _config):
     qubit, *qumodes = op.wires.tolist()
-    drawer.z_conditional(
-        layer, [qubit], wires_target=min(qumodes), control_values=[True]
-    )
+    drawer.z_conditional(layer, [qubit], wires_target=qumodes)
 
     new_op = ops.TwoModeSum(*op.parameters, wires=qumodes)
     _add_operation_to_drawer(new_op, drawer, layer, _config)
@@ -118,19 +114,14 @@ def _draw_icons(
     show_all_wires=False,
     wire_icon_colors: dict[Any, str] | None = None,
 ):
-    sa_res = sa.type_check(tape)
-
+    type_res = cast(sa.TypeCheckResult, sa.type_check(tape))
     _, wire_map = convert_wire_order(
         tape, wire_order=wire_order, show_all_wires=show_all_wires
     )
 
-    # This section assumes the types of all wires can be inferred
-    wire_colors = _get_default_colors(wire_map, sa_res) | (wire_icon_colors or {})
-    icons = []
-    colors = []
-    for wire_label in wire_map:
-        icons.append("qumode" if wire_label in sa_res.qumodes else "qubit")
-        colors.append(wire_colors[wire_label])
+    icons = [type_res.wire_types[w] for w in wire_map]
+    wire_colors = _get_default_colors(wire_map, type_res) | (wire_icon_colors or {})
+    colors = [wire_colors[w] for w in wire_map]
 
     drawer.wire_icons(icons, colors)
 
@@ -164,12 +155,13 @@ def tape_mpl(
 
         show_wire_types: If True, draw qumode/qubit icons next to each wire
 
-        wire_icon_colors (dict | None): A dict of wires -> colors to use for each wire icon. If a wire
-            is not provided, a default color will be used (``mediumseagreen`` for qumodes and ``darkorchid``
-            for qubits). Colors are anything compatible with Matplotlib.
+        wire_icon_colors (dict | None): A dict of wires -> colors to use for each wire icon. If a
+            wire is not provided, a default color will be used (``mediumseagreen`` for qumodes and
+            ``darkorchid`` for qubits). Colors are anything compatible with Matplotlib.
 
     Returns:
-        matplotlib.figure.Figure, matplotlib.axes._axes.Axes: the return of :py:func:`qp.draw_mpl <pennylane.drawer.draw.draw_mpl>`
+        matplotlib.figure.Figure, matplotlib.axes._axes.Axes: the return of
+            :py:func:`qp.draw_mpl <pennylane.drawer.draw.draw_mpl>`
 
     .. seealso::
 
@@ -212,9 +204,12 @@ def _get_default_colors(
 ) -> dict[Any, str]:
     result = {}
     for wire in wire_map:
-        if wire in checked_types.qubits:
-            result[wire] = default_qubit_color
-        elif wire in checked_types.qumodes:
-            result[wire] = default_qumode_color
+        match checked_types.wire_types[wire]:
+            case sa.Qubit():
+                result[wire] = default_qubit_color
+            case sa.Qumode():
+                result[wire] = default_qumode_color
+            case sa.Qudit():  # pragma: no cover
+                raise NotImplementedError("Drawing qudit circuits is not yet supported")
 
     return result

--- a/test/draw/test_draw_mpl.py
+++ b/test/draw/test_draw_mpl.py
@@ -1,6 +1,9 @@
 # SPDX-FileCopyrightText: 2025 Battelle Memorial Institute
 # SPDX-License-Identifier: BSD-2-Clause
 
+from collections.abc import Callable
+from functools import partial
+
 import pennylane as qp
 import pytest
 
@@ -16,37 +19,72 @@ from hybridlane.drawer.tape_mpl import (  # noqa: E402
 )
 
 
-def get_circuit1():
-    dev = qp.device("bosonicqiskit.hybrid", max_fock_level=8)
+def circuit1(n):
+    qp.H(0)
+    hl.R(0.5, 1)
 
-    @qp.qnode(dev)
-    def circuit1(n):
-        qp.H(0)
-        hl.Rotation(0.5, 1)
+    for i in range(n):
+        hl.CD(0.5, 0, [0, 2 + i])
 
-        for i in range(n):
-            hl.ConditionalDisplacement(0.5, 0, [0, 2 + i])
-
-        return hl.expval(hl.NumberOperator(n))
-
-    return circuit1
+    return hl.expval(hl.N(n))
 
 
-@pytest.mark.bq
+def circuit2():
+    # This is just a circuit with all the custom conditional gates in it
+    qp.H(0)
+    hl.CS(0.123, 0.456, wires=(0, 1))
+    hl.ModeSwap((1, 2))
+    hl.CP((0, 1))
+    hl.CR(0.123, wires=(0, 2))
+    hl.CBS(0.123, 0.456, wires=(0, 1, 2))
+    hl.CTMS(0.123, 0.456, wires=(0, 1, 2))
+    hl.CSUM(0.5, wires=(0, 1, 2))
+
+    return hl.expval(hl.N(2))
+
+
+def circuit3():
+    # Same thing but we're mixing string and int labels
+    qp.H(0)
+    hl.CS(0.123, 0.456, wires=(0, "m"))
+    hl.ModeSwap(("m", 2))
+    hl.CP((0, "m"))
+    hl.CR(0.123, wires=(0, 2))
+    hl.CBS(0.123, 0.456, wires=(0, "m", 2))
+    hl.CTMS(0.123, 0.456, wires=(0, "m", 2))
+    hl.CSUM(0.5, wires=(0, "m", 2))
+
+    return hl.expval(hl.N(2))
+
+
 @pytest.mark.unit
-class TestIconBehavior:
-    def test_icon_colors(self):
-        icon_colors = {
-            2: "tomato",
-            3: "orange",
-            4: "gold",
-            5: "lime",
-            6: "turquoise",
-        }
+@pytest.mark.parametrize("f", [partial(circuit1, 3), circuit2, circuit3])
+def test_draw_mpl_doesnt_error(f: Callable):
+    # Test with callable invocation
+    _, ax = hl.draw_mpl(f)()
+    plt.close("all")
 
-        circuit1 = get_circuit1()
-        fig, ax = hl.draw_mpl(
-            circuit1,
+    # Test with qnode input
+    dev = qp.device("default.hybrid", fock_level=8)
+    qnode = qp.QNode(f, dev)
+    _, ax = hl.draw_mpl(qnode)()
+    plt.close("all")
+
+
+@pytest.mark.unit
+def test_icon_colors():
+    icon_colors = {
+        2: "tomato",
+        3: "orange",
+        4: "gold",
+        5: "lime",
+        6: "turquoise",
+    }
+
+    dev = qp.device("default.hybrid", fock_level=8)
+    for input in (circuit1, qp.QNode(circuit1, dev)):
+        _, ax = hl.draw_mpl(
+            input,
             wire_icon_colors=icon_colors,
         )(5)
 
@@ -72,3 +110,15 @@ class TestIconBehavior:
             )
 
         plt.close("all")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "f,wire_order", [(circuit2, (1, 0, 2)), (circuit3, ("m", 0, 2))]
+)
+def test_overlapping_qcond_warns(f, wire_order):
+    dev = qp.device("default.hybrid", fock_level=8)
+    for input in (f, qp.QNode(f, dev)):
+        # put the qubit between the qumodes so that the BS gate is drawn overtop the qubit wire
+        with pytest.warns(UserWarning):
+            _, ax = hl.draw_mpl(input, wire_order=wire_order)()

--- a/uv.lock
+++ b/uv.lock
@@ -741,13 +741,7 @@ qscout = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "jax" },
-    { name = "openqasm3", extra = ["parser"] },
-    { name = "optax" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
     { name = "ruff" },
-    { name = "sybil", extra = ["pytest"] },
     { name = "ty" },
 ]
 docs = [
@@ -759,6 +753,15 @@ docs = [
     { name = "sphinx-copybutton" },
     { name = "sphinx-math-dollar" },
     { name = "sphinxcontrib-bibtex" },
+]
+test = [
+    { name = "jax" },
+    { name = "matplotlib" },
+    { name = "openqasm3", extra = ["parser"] },
+    { name = "optax" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "sybil", extra = ["pytest"] },
 ]
 
 [package.metadata]
@@ -775,13 +778,7 @@ provides-extras = ["bq", "all", "qscout"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "jax", specifier = ">=0.10.1" },
-    { name = "openqasm3", extras = ["parser"], specifier = ">=1.0.1" },
-    { name = "optax", specifier = ">=0.2.8" },
-    { name = "pytest", specifier = ">=8.4.1" },
-    { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "ruff", specifier = ">=0.12.0" },
-    { name = "sybil", extras = ["pytest"], specifier = ">=9.3.0" },
     { name = "ty", specifier = ">=0.0.39" },
 ]
 docs = [
@@ -792,6 +789,15 @@ docs = [
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
     { name = "sphinx-math-dollar", specifier = ">=1.2.1" },
     { name = "sphinxcontrib-bibtex", specifier = ">=2.6.5" },
+]
+test = [
+    { name = "jax", specifier = ">=0.10.1" },
+    { name = "matplotlib", specifier = ">=3.10.9" },
+    { name = "openqasm3", extras = ["parser"], specifier = ">=1.0.1" },
+    { name = "optax", specifier = ">=0.2.8" },
+    { name = "pytest", specifier = ">=8.4.1" },
+    { name = "pytest-cov", specifier = ">=6.2.1" },
+    { name = "sybil", extras = ["pytest"], specifier = ">=9.3.0" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -741,7 +741,14 @@ qscout = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "jax" },
+    { name = "matplotlib" },
+    { name = "openqasm3", extra = ["parser"] },
+    { name = "optax" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "sybil", extra = ["pytest"] },
     { name = "ty" },
 ]
 docs = [
@@ -753,15 +760,6 @@ docs = [
     { name = "sphinx-copybutton" },
     { name = "sphinx-math-dollar" },
     { name = "sphinxcontrib-bibtex" },
-]
-test = [
-    { name = "jax" },
-    { name = "matplotlib" },
-    { name = "openqasm3", extra = ["parser"] },
-    { name = "optax" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
-    { name = "sybil", extra = ["pytest"] },
 ]
 
 [package.metadata]
@@ -778,7 +776,14 @@ provides-extras = ["bq", "all", "qscout"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "jax", specifier = ">=0.10.1" },
+    { name = "matplotlib", specifier = ">=3.10.9" },
+    { name = "openqasm3", extras = ["parser"], specifier = ">=1.0.1" },
+    { name = "optax", specifier = ">=0.2.8" },
+    { name = "pytest", specifier = ">=8.4.1" },
+    { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "ruff", specifier = ">=0.12.0" },
+    { name = "sybil", extras = ["pytest"], specifier = ">=9.3.0" },
     { name = "ty", specifier = ">=0.0.39" },
 ]
 docs = [
@@ -789,15 +794,6 @@ docs = [
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
     { name = "sphinx-math-dollar", specifier = ">=1.2.1" },
     { name = "sphinxcontrib-bibtex", specifier = ">=2.6.5" },
-]
-test = [
-    { name = "jax", specifier = ">=0.10.1" },
-    { name = "matplotlib", specifier = ">=3.10.9" },
-    { name = "openqasm3", extras = ["parser"], specifier = ">=1.0.1" },
-    { name = "optax", specifier = ">=0.2.8" },
-    { name = "pytest", specifier = ">=8.4.1" },
-    { name = "pytest-cov", specifier = ">=6.2.1" },
-    { name = "sybil", extras = ["pytest"], specifier = ">=9.3.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
This fixes a bug where kwargs like `wire_icon_colors` wouldn't get
passed to `tape_mpl` if calling `draw_mpl` on a non-QNode callable.

It also improves test coverage of circuit drawing and adds mpl to
the test dependencies so the drawing tests won't get skipped.
