### PR TITLE
Fix JC/AJC simplify

### DIFF
--- a/docs/releases/changelog-0.8.0.md
+++ b/docs/releases/changelog-0.8.0.md
@@ -227,6 +227,8 @@
 
 - `wire_icon_colors` keyword argument is now properly passed down when calling `hl.draw_mpl` on a non-QNode callable (#72)
 
+- The `simplify()` method of the JC and AJC gates is no longer periodic in theta (#74)
+
 ### Miscellaneous
 
 - Added a `justfile` to facilitate running common developer tasks (#42)

--- a/src/hybridlane/ops/hybrid/parametric_ops_single_qumode.py
+++ b/src/hybridlane/ops/hybrid/parametric_ops_single_qumode.py
@@ -800,7 +800,7 @@ class JaynesCummings(HybridOperation, FockRepresentation):
         super().__init__(theta, phi, wires=wires, id=id)
 
     def simplify(self):
-        theta = self.data[0] % (2 * math.pi)
+        theta = self.data[0]
         phi = self.data[1] % (2 * math.pi)
 
         if _can_replace(theta, 0):
@@ -922,7 +922,7 @@ class AntiJaynesCummings(HybridOperation, FockRepresentation):
         super().__init__(theta, phi, wires=wires, id=id)
 
     def simplify(self):
-        theta = self.data[0] % (2 * math.pi)
+        theta = self.data[0]
         phi = self.data[1] % (2 * math.pi)
 
         if _can_replace(theta, 0):

--- a/test/ops/hybrid/test_parametric_ops_single_qumode.py
+++ b/test/ops/hybrid/test_parametric_ops_single_qumode.py
@@ -219,6 +219,11 @@ class TestJaynesCummings:
         simplified_op = op.simplify()
         assert isinstance(simplified_op, qp.Identity)
 
+        # JC is not periodic w.r.t. theta
+        op = hl.JC(5 * math.pi, 0.3, wires=[0, 1])
+        simplified_op = op.simplify()
+        assert simplified_op.parameters == pytest.approx(op.parameters)
+
     def test_label(self):
         op = hl.JaynesCummings(0.5, 0.3, wires=[0, 1])
         assert op.label() == "JC"
@@ -347,6 +352,11 @@ class TestAntiJaynesCummings:
         op = hl.AntiJaynesCummings(0, 0.3, wires=[0, 1])
         simplified_op = op.simplify()
         assert isinstance(simplified_op, qp.Identity)
+
+        # AJC is not periodic w.r.t. theta
+        op = hl.AJC(5 * math.pi, 0.3, wires=[0, 1])
+        simplified_op = op.simplify()
+        assert simplified_op.parameters == pytest.approx(op.parameters)
 
     def test_label(self):
         op = hl.AntiJaynesCummings(0.5, 0.3, wires=[0, 1])

--- a/test/templates/test_non_abelian_qsp.py
+++ b/test/templates/test_non_abelian_qsp.py
@@ -23,12 +23,10 @@ def cat_state_probs(alpha, ns, odd: bool):
     return np.exp(log_Pn)
 
 
-# @pytest.mark.slow
-# @pytest.mark.bq
 class TestSqueezedCatState:
     @pytest.mark.integration
     @pytest.mark.parametrize(
-        "alpha,parity", itertools.product([3, 4, 5, 6], ("even", "odd"))
+        "alpha,parity", list(itertools.product([3, 4, 5, 6], ("even", "odd")))
     )
     def test_parity(self, alpha, parity):
         fock_level = 128


### PR DESCRIPTION
Fixes the JC and AJC gates to not define their `simplify()` functions
to be periodic w.r.t. theta.
