### PR TITLE
Fix inference of primitive qubit ops

### DIFF
--- a/src/hybridlane/wires/type_check.py
+++ b/src/hybridlane/wires/type_check.py
@@ -20,7 +20,7 @@ from pennylane.typing import TensorLike
 from pennylane.wires import WiresLike
 
 from ..ops import QubitConditioned
-from ..ops.mixins import Hybrid, Spectral
+from ..ops.mixins import Hybrid, HybridOperation, Spectral
 from .base import (
     BasisMap,
     ComputationalBasis,
@@ -174,14 +174,16 @@ def _(op: Operator, context: Context) -> Context:
     elif module.startswith("pennylane.ops.qutrit"):
         return context | {w: Qudit(3) for w in op.wires}
 
-    # Makes this robust to MRO ordering
+    # Even though we have a branch below for Hybrid, depending on the inheritance order, a Hybrid
+    # gate may end up here. So we handle it again just in case.
     if isinstance(op, Hybrid):
         return _infer_from_hybrid(op, context)
 
     if op.has_decomposition:
         return infer_wires(op.decomposition(), context)
 
-    raise TypeCheckError(f"Unable to infer wire types for operation {op}")
+    # We have to assume that this is a custom primitive qubit operation with no decompositions.
+    return context | {w: Qubit() for w in op.wires}
 
 
 @infer_wires.register
@@ -199,7 +201,7 @@ def _(op: CVOperation | CVObservable, context: Context):
 
 
 @infer_wires.register
-def _infer_from_hybrid(op: Hybrid, context: Context):
+def _infer_from_hybrid(op: Hybrid | HybridOperation, context: Context):
     return context | op.wire_types()
 
 

--- a/test/devices/sandia_qscout/test_ops.py
+++ b/test/devices/sandia_qscout/test_ops.py
@@ -1,0 +1,12 @@
+import pennylane as qp
+
+import hybridlane as hl
+from hybridlane.devices.sandia_qscout import ops
+from hybridlane.wires.type_check import infer_wires
+
+
+class TestR:
+    def test_type_check(self):
+        op = ops.R(0.123, 0.456, wires=0)
+        context = infer_wires(op, {})
+        assert context == {0: hl.Qubit()}

--- a/test/wires/test_type_check.py
+++ b/test/wires/test_type_check.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 import pennylane as qp
 import pytest
-from pennylane.operation import Operator
+from pennylane.operation import Operation, Operator
 from pennylane.tape import QuantumScript
 from pennylane.wires import Wires
 
@@ -10,6 +10,15 @@ import hybridlane as hl
 from hybridlane.measurements import ComputationalBasis
 from hybridlane.wires import Qubit, TypedWires, infer_measurement_bases, type_check
 from hybridlane.wires.type_check import infer_wires
+
+
+# Operator to test that people can create primitive qubit operators outside of pennylane
+class DummyQubitOperator(Operation):
+    num_wires = 2
+    num_params = 0
+
+    def __init__(self, wires):
+        super().__init__(wires=wires)
 
 
 @pytest.mark.unit
@@ -61,6 +70,7 @@ class TestWireTypeChecking:
             qp.Projector([1, 0, 1], wires=(0, 1, 2)),
             qp.MultiRZ(0.1, wires=range(10)),
             qp.Hermitian([[1, 0], [0, 1]], wires=1),
+            DummyQubitOperator(wires=(0, 1)),
         ],
     )
     def test_with_qubit_ops(self, op: Operator):


### PR DESCRIPTION
Fixes inferring types of `Operation` that do not define a decomposition.
