### PR TITLE
Switch to `concrete_or_error`

### DIFF
--- a/src/hybridlane/devices/sandia_qscout/ops.py
+++ b/src/hybridlane/devices/sandia_qscout/ops.py
@@ -12,7 +12,7 @@ from pennylane.wires import WiresLike
 
 import hybridlane as hl
 
-from ...ops.hybrid.parametric_ops_single_qumode import _can_replace
+from ...math.utils import can_replace, concrete_or_error
 from ...ops.mixins import HybridOperation
 
 Red = hl.Red
@@ -174,19 +174,23 @@ class R(Operation):
     def simplify(self):
         theta, phi = self.data[0] % (4 * math.pi), self.data[1] % math.pi
 
-        if _can_replace(theta, 0):
+        theta = concrete_or_error(
+            None, theta, "Cannot simplify R when ``theta`` is a tracer"
+        )
+        phi = concrete_or_error(None, phi, "Cannot simplify R when ``phi`` is a tracer")
+        if can_replace(theta, 0):
             return qp.Identity(wires=self.wires)
 
-        elif _can_replace(phi, 0):
+        elif can_replace(phi, 0):
             return qp.RX(theta, wires=self.wires)
 
-        elif _can_replace(phi, math.pi / 2):
+        elif can_replace(phi, math.pi / 2):
             return qp.RY(theta, wires=self.wires)
 
-        elif _can_replace(phi, -math.pi):
+        elif can_replace(phi, -math.pi):
             return qp.RX(-theta, wires=self.wires)
 
-        elif _can_replace(phi, -math.pi / 2):
+        elif can_replace(phi, -math.pi / 2):
             return qp.RY(theta, wires=self.wires)
 
         return R(theta, phi, wires=self.wires)

--- a/src/hybridlane/math/__init__.py
+++ b/src/hybridlane/math/__init__.py
@@ -5,11 +5,14 @@ r"""A wrapper around :mod:`pennylane.math` providing tensor-library agnostic fun
 import autoray as ar
 from pennylane import math as pl_math
 
-from . import array_manipulation  # noqa: F401
-from . import symplectic  # noqa: F401
+from . import (
+    array_manipulation,  # noqa: F401
+    symplectic,  # noqa: F401
+)
 from .matrix_manipulation import expand_matrix, expand_vector
 from .quantum import reduce_dm, reduce_statevector
 from .symplectic import is_symplectic, symplectic_form, to_fock_space, to_phase_space
+from .utils import concrete_or_error
 
 dag = ar.dag
 
@@ -41,4 +44,5 @@ __all__ = [
     "symplectic_form",
     "to_fock_space",
     "to_phase_space",
+    "concrete_or_error",
 ] + pl_math.__all__

--- a/src/hybridlane/math/utils.py
+++ b/src/hybridlane/math/utils.py
@@ -1,0 +1,43 @@
+from collections.abc import Callable
+
+import pennylane as qp
+from pennylane.typing import TensorLike
+
+
+def concrete_or_error(
+    f: Callable | None, x: TensorLike, context: str = "", like: str | None = None
+) -> TensorLike:
+    r"""Errors if the input is a tracer that can't be concretized with ``f``
+
+    This function behaves like ``jax.extend.core.concrete_or_error``
+
+    Args:
+        f: The optional function to use to concretize the input. If set, the return value will
+            be ``f(x)``. If not set, the return value will be ``x``.
+
+        x: The input to check for tracers
+
+        context: The context to use in the error message if an error is raised
+
+        like: The interface to use. If not set, the interface will be inferred from ``x``.
+
+    Returns:
+        The result of ``f(x)`` if ``f`` is not None, otherwise ``x``.
+
+    Raises:
+        ValueError: If ``x`` is a tracer that can't be concretized with ``f``.
+    """
+    like = like or qp.math.get_interface(x)
+
+    if like == "jax":
+        import jax.core
+        from jax.extend.core import concrete_or_error
+
+        if isinstance(x, jax.core.Tracer):
+            return concrete_or_error(f, x, context=context)
+
+    return f(x) if f is not None else x
+
+
+def can_replace(x: TensorLike, y: TensorLike) -> bool:
+    return not qp.math.requires_grad(x) and qp.math.allclose(x, y)

--- a/src/hybridlane/ops/hybrid/parametric_ops_multi_qumode.py
+++ b/src/hybridlane/ops/hybrid/parametric_ops_multi_qumode.py
@@ -12,6 +12,7 @@ from pennylane.wires import WiresLike
 
 import hybridlane as hl
 
+from ...math.utils import can_replace, concrete_or_error
 from ..mixins import FockRepresentation, HybridOperation
 from ..op_math.decompositions.qubit_conditioned_decompositions import (
     decompose_multiqcond_native,
@@ -91,7 +92,10 @@ class ConditionalBeamsplitter(HybridOperation, FockRepresentation):
         theta = self.data[0] % (4 * math.pi)
         phi = self.data[1] % math.pi
 
-        if _can_replace(theta, 0):
+        theta = concrete_or_error(
+            None, theta, "Cannot simplify CBS when ``theta`` is a tracer"
+        )
+        if can_replace(theta, 0):
             return qp.Identity(self.wires)
 
         return ConditionalBeamsplitter(theta, phi, self.wires)
@@ -208,7 +212,8 @@ class ConditionalTwoModeSqueezing(HybridOperation, FockRepresentation):
     def simplify(self):
         r, phi = self.data[0], self.data[1] % (2 * math.pi)
 
-        if _can_replace(r, 0):
+        r = concrete_or_error(None, r, "Cannot simplify CTMS when ``r`` is a tracer")
+        if can_replace(r, 0):
             return qp.Identity(self.wires)
 
         return ConditionalTwoModeSqueezing(r, phi, self.wires)
@@ -309,7 +314,11 @@ class ConditionalTwoModeSum(HybridOperation, FockRepresentation):
 
     def simplify(self):
         lambda_ = self.data[0]
-        if _can_replace(lambda_, 0):
+
+        lambda_ = concrete_or_error(
+            None, lambda_, "Cannot simplify CSUM when ``lambda`` is a tracer"
+        )
+        if can_replace(lambda_, 0):
             return qp.Identity(self.wires)
 
         return ConditionalTwoModeSum(lambda_, self.wires)
@@ -341,11 +350,3 @@ r"""Qubit-conditioned two-mode sum gate :math:`CSUM(\lambda)`
 
     This is an alias for :class:`~hybridlane.ConditionalTwoModeSum`
 """
-
-
-def _can_replace(x, y):
-    return (
-        not qp.math.is_abstract(x)
-        and not qp.math.requires_grad(x)
-        and qp.math.allclose(x, y)
-    )

--- a/src/hybridlane/ops/hybrid/parametric_ops_single_qumode.py
+++ b/src/hybridlane/ops/hybrid/parametric_ops_single_qumode.py
@@ -13,6 +13,7 @@ from pennylane.wires import WiresLike
 
 import hybridlane as hl
 
+from ...math.utils import can_replace, concrete_or_error
 from ..mixins import FockRepresentation, HybridOperation
 from ..op_math.decompositions.qubit_conditioned_decompositions import (
     decompose_multiqcond_native,
@@ -80,7 +81,10 @@ class ConditionalRotation(HybridOperation, FockRepresentation):
     def simplify(self):
         theta = self.data[0] % (4 * math.pi)
 
-        if _can_replace(theta, 0):
+        theta = concrete_or_error(
+            None, theta, "Cannot simplify CR when ``theta`` is a tracer"
+        )
+        if can_replace(theta, 0):
             return qp.Identity(self.wires)
 
         return ConditionalRotation(theta, self.wires)
@@ -185,7 +189,8 @@ class ConditionalDisplacement(HybridOperation, FockRepresentation):
     def simplify(self):
         a, phi = self.data[0], self.data[1] % (2 * math.pi)
 
-        if _can_replace(a, 0):
+        a = concrete_or_error(None, a, "Cannot simplify CD when ``a`` is a tracer")
+        if can_replace(a, 0):
             return qp.Identity(self.wires)
 
         return ConditionalDisplacement(a, phi, self.wires)
@@ -313,7 +318,8 @@ class ConditionalXDisplacement(HybridOperation, FockRepresentation):
     def simplify(self):
         a, phi = self.data[0], self.data[1] % (2 * math.pi)
 
-        if _can_replace(a, 0):
+        a = concrete_or_error(None, a, "Cannot simplify xCD when ``a`` is a tracer")
+        if can_replace(a, 0):
             return qp.Identity(self.wires)
 
         return ConditionalXDisplacement(a, phi, self.wires)
@@ -421,7 +427,8 @@ class ConditionalYDisplacement(HybridOperation, FockRepresentation):
     def simplify(self):
         a, phi = self.data[0], self.data[1] % (2 * math.pi)
 
-        if _can_replace(a, 0):
+        a = concrete_or_error(None, a, "Cannot simplify yCD when ``a`` is a tracer")
+        if can_replace(a, 0):
             return qp.Identity(self.wires)
 
         return ConditionalYDisplacement(a, phi, self.wires)
@@ -557,7 +564,8 @@ class ConditionalSqueezing(HybridOperation, FockRepresentation):
     def simplify(self):
         z, theta = self.data[0], self.data[1] % math.pi
 
-        if _can_replace(z, 0):
+        z = concrete_or_error(None, z, "Cannot simplify CS when ``z`` is a tracer")
+        if can_replace(z, 0):
             return qp.Identity(self.wires)
 
         return ConditionalSqueezing(z, theta, self.wires)
@@ -677,7 +685,10 @@ class SelectiveQubitRotation(HybridOperation, FockRepresentation):
         phi = phi % (2 * math.pi)
         n = self.hyperparameters["n"]
 
-        if _can_replace(theta, 0):
+        theta = concrete_or_error(
+            None, theta, "Cannot simplify SQR when ``theta`` is a tracer"
+        )
+        if can_replace(theta, 0):
             return qp.Identity(self.wires)
 
         return SelectiveQubitRotation(theta, phi, n, self.wires)
@@ -803,7 +814,10 @@ class JaynesCummings(HybridOperation, FockRepresentation):
         theta = self.data[0]
         phi = self.data[1] % (2 * math.pi)
 
-        if _can_replace(theta, 0):
+        theta = concrete_or_error(
+            None, theta, "Cannot simplify JC when ``theta`` is a tracer"
+        )
+        if can_replace(theta, 0):
             return qp.Identity(self.wires)
 
         return JaynesCummings(theta, phi, self.wires)
@@ -925,7 +939,10 @@ class AntiJaynesCummings(HybridOperation, FockRepresentation):
         theta = self.data[0]
         phi = self.data[1] % (2 * math.pi)
 
-        if _can_replace(theta, 0):
+        theta = concrete_or_error(
+            None, theta, "Cannot simplify AJC when ``theta`` is a tracer"
+        )
+        if can_replace(theta, 0):
             return qp.Identity(self.wires)
 
         return AntiJaynesCummings(theta, phi, self.wires)
@@ -1032,7 +1049,8 @@ class Rabi(HybridOperation, FockRepresentation):
         r = self.data[0]
         phi = self.data[1] % (2 * math.pi)
 
-        if _can_replace(r, 0):
+        r = concrete_or_error(None, r, "Cannot simplify RB when ``r`` is a tracer")
+        if can_replace(r, 0):
             return qp.Identity(self.wires)
 
         return Rabi(r, phi, self.wires)
@@ -1140,7 +1158,8 @@ class EchoedConditionalDisplacement(HybridOperation, FockRepresentation):
     def simplify(self):
         a, phi = self.data[0], self.data[1] % (2 * math.pi)
 
-        if _can_replace(a, 0):
+        a = concrete_or_error(None, a, "Cannot simplify ECD when ``a`` is a tracer")
+        if can_replace(a, 0):
             return qp.Identity(self.wires)
 
         return EchoedConditionalDisplacement(a, phi, self.wires)
@@ -1184,11 +1203,3 @@ r"""Echoed-conditional displacement (ECD) gate
 
 This is an alias for :class:`~hybridlane.EchoedConditionalDisplacement`
 """
-
-
-def _can_replace(x, y):
-    return (
-        not qp.math.is_abstract(x)
-        and not qp.math.requires_grad(x)
-        and qp.math.allclose(x, y)
-    )

--- a/src/hybridlane/ops/qumode/parametric_ops_multi_qumode.py
+++ b/src/hybridlane/ops/qumode/parametric_ops_multi_qumode.py
@@ -15,6 +15,7 @@ from pennylane.wires import WiresLike
 
 import hybridlane as hl
 
+from ...math.utils import can_replace, concrete_or_error
 from ..mixins import FockRepresentation
 from ..op_math.decompositions.qubit_conditioned_decompositions import to_native_qcond
 
@@ -131,7 +132,10 @@ class Beamsplitter(CVOperation, FockRepresentation):
         theta = self.data[0] % (4 * math.pi)
         phi = self.data[1] % (2 * math.pi)
 
-        if _can_replace(theta, 0):
+        theta = concrete_or_error(
+            None, theta, "Cannot simplify BS when ``theta`` is a tracer"
+        )
+        if can_replace(theta, 0):
             return qp.Identity(wires=self.wires)
 
         return Beamsplitter(theta, phi, self.wires)
@@ -282,7 +286,8 @@ class TwoModeSqueezing(CVOperation, FockRepresentation):
         r = self.data[0]
         phi = self.data[1] % (2 * math.pi)
 
-        if _can_replace(r, 0):
+        r = concrete_or_error(None, r, "Cannot simplify TMS when ``r`` is a tracer")
+        if can_replace(r, 0):
             return qp.Identity(self.wires)
 
         return TwoModeSqueezing(r, phi, self.wires)
@@ -425,7 +430,11 @@ class TwoModeSum(CVOperation, FockRepresentation):
 
     def simplify(self):
         lambda_ = self.data[0]
-        if _can_replace(lambda_, 0):
+
+        lambda_ = concrete_or_error(
+            None, lambda_, "Cannot simplify SUM when ``lambda`` is a tracer"
+        )
+        if can_replace(lambda_, 0):
             return qp.Identity(self.wires)
 
         return TwoModeSum(lambda_, self.wires)
@@ -464,11 +473,3 @@ r"""Two-mode summing gate :math:`SUM(\lambda)`
 
     This is an alias of :class:`~hybridlane.TwoModeSum`
 """
-
-
-def _can_replace(x, y):
-    return (
-        not qp.math.is_abstract(x)
-        and not qp.math.requires_grad(x)
-        and qp.math.allclose(x, y)
-    )

--- a/src/hybridlane/ops/qumode/parametric_ops_single_qumode.py
+++ b/src/hybridlane/ops/qumode/parametric_ops_single_qumode.py
@@ -14,6 +14,7 @@ from pennylane.wires import WiresLike
 
 import hybridlane as hl
 
+from ...math.utils import can_replace, concrete_or_error
 from ..mixins import FockRepresentation
 from ..op_math.decompositions.qubit_conditioned_decompositions import to_native_qcond
 
@@ -116,7 +117,8 @@ class Displacement(CVOperation, FockRepresentation):
     def simplify(self):
         a, phi = self.parameters[0], self.parameters[1] % (2 * math.pi)
 
-        if _can_replace(a, 0):
+        a = concrete_or_error(None, a, "Cannot simplify D when ``a`` is a tracer")
+        if can_replace(a, 0):
             return qp.Identity(self.wires)
 
         return Displacement(a, phi, self.wires)
@@ -226,7 +228,10 @@ class Rotation(CVOperation, FockRepresentation):
     def simplify(self):
         theta = self.data[0] % (2 * math.pi)
 
-        if _can_replace(theta, 0):
+        theta = concrete_or_error(
+            None, theta, "Cannot simplify R when ``theta`` is a tracer"
+        )
+        if can_replace(theta, 0):
             return qp.Identity(wires=self.wires)
 
         return Rotation(theta, self.wires)
@@ -343,7 +348,8 @@ class Squeezing(CVOperation, FockRepresentation):
     def simplify(self):
         r, phi = self.data[0], self.data[1] % math.pi
 
-        if _can_replace(r, 0):
+        r = concrete_or_error(None, r, "Cannot simplify S when ``r`` is a tracer")
+        if can_replace(r, 0):
             return qp.Identity(self.wires)
 
         return Squeezing(r, phi, self.wires)
@@ -423,7 +429,10 @@ class Kerr(CVOperation, FockRepresentation):
     def simplify(self):
         kappa = self.data[0] % (2 * math.pi)
 
-        if _can_replace(kappa, 0):
+        kappa = concrete_or_error(
+            None, kappa, "Cannot simplify K when ``kappa`` is a tracer"
+        )
+        if can_replace(kappa, 0):
             return qp.Identity(wires=self.wires)
 
         return Kerr(kappa, self.wires)
@@ -487,7 +496,9 @@ class CubicPhase(CVOperation, FockRepresentation):
 
     def simplify(self):
         r = self.data[0]
-        if _can_replace(r, 0):
+
+        r = concrete_or_error(None, r, "Cannot simplify C when ``r`` is a tracer")
+        if can_replace(r, 0):
             return qp.Identity(wires=self.wires)
 
         return self
@@ -630,7 +641,10 @@ class SelectiveNumberArbitraryPhase(CVOperation, FockRepresentation):
         phi = self.data[0] % (2 * math.pi)
         n = self.hyperparameters["n"]
 
-        if _can_replace(phi, 0):
+        phi = concrete_or_error(
+            None, phi, "Cannot simplify SNAP when ``phi`` is a tracer"
+        )
+        if can_replace(phi, 0):
             return qp.Identity(self.wires)
 
         return SelectiveNumberArbitraryPhase(phi, n, self.wires)
@@ -681,11 +695,3 @@ def _snap_to_sqr(phi, wires, n, **_):
 qp.add_decomps(SNAP, _snap_to_sqr)
 qp.add_decomps("Adjoint(SelectiveNumberArbitraryPhase)", adjoint_rotation)
 qp.add_decomps("Pow(SelectiveNumberArbitraryPhase)", pow_rotation)
-
-
-def _can_replace(x, y):
-    return (
-        not qp.math.is_abstract(x)
-        and not qp.math.requires_grad(x)
-        and qp.math.allclose(x, y)
-    )


### PR DESCRIPTION
Updates the `.simplify()` logic of the operations to use
`jax.extend.core.concrete_or_error` because `jax.core.is_concrete`
was deprecated.
