### PR TITLE
fix: ecd simplify

### DIFF
--- a/docs/releases/changelog-0.8.0.md
+++ b/docs/releases/changelog-0.8.0.md
@@ -231,6 +231,8 @@
 
 - The `simplify()` method of the JC and AJC gates is no longer periodic in theta (#74)
 
+- The `simplify()` method of the ECD gate now simplifies to `qp.X` when alpha is 0 (#89)
+
 ### Miscellaneous
 
 - Added a `justfile` to facilitate running common developer tasks (#42)

--- a/src/hybridlane/ops/hybrid/parametric_ops_single_qumode.py
+++ b/src/hybridlane/ops/hybrid/parametric_ops_single_qumode.py
@@ -1140,7 +1140,8 @@ class EchoedConditionalDisplacement(HybridOperation, FockRepresentation):
 
         a = concrete_or_error(None, a, "Cannot simplify ECD when ``a`` is a tracer")
         if can_replace(a, 0):
-            return qp.Identity(self.wires)
+            # Because ECD(a) = X CD(a/2), ECD(0) = X
+            return qp.X(self.wires[0])
 
         return EchoedConditionalDisplacement(a, phi, self.wires)
 

--- a/test/ops/hybrid/test_parametric_ops_single_qumode.py
+++ b/test/ops/hybrid/test_parametric_ops_single_qumode.py
@@ -898,7 +898,7 @@ class TestEchoedConditionalDisplacement:
     def test_simplify(self):
         op = hl.EchoedConditionalDisplacement(0, 0.123, wires=[0, 1])
         simplified_op = op.simplify()
-        assert isinstance(simplified_op, qp.Identity)
+        assert simplified_op == qp.X(0)
 
     def test_label(self):
         op = hl.EchoedConditionalDisplacement(0.5, 0, wires=[0, 1])


### PR DESCRIPTION
Fixes the definition of simplify for the ECD gate so that ECD(0) = X, matching
its definition of ECD(a) = X CD(a). The previous version set ECD(0) = I.
