### PR TITLE
fix: ecd properties

### DIFF
--- a/docs/releases/changelog-0.8.0.md
+++ b/docs/releases/changelog-0.8.0.md
@@ -231,7 +231,7 @@
 
 - The `simplify()` method of the JC and AJC gates is no longer periodic in theta (#74)
 
-- The `simplify()` method of the ECD gate now simplifies to `qp.X` when alpha is 0 (#89)
+- Updated the algebraic properties of the ECD gate to be self-adjoint (#89) (#90)
 
 ### Miscellaneous
 

--- a/src/hybridlane/ops/hybrid/parametric_ops_single_qumode.py
+++ b/src/hybridlane/ops/hybrid/parametric_ops_single_qumode.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # ruff: noqa: D107, D102
 r"""Hybrid CV-DV operations acting on a single qumode"""
-
 import math
 from typing import ClassVar
 
@@ -10,8 +9,11 @@ import pennylane as qp
 from pennylane.decomposition.resources import adjoint_resource_rep
 from pennylane.decomposition.symbolic_decomposition import (
     adjoint_rotation,
+    pow_involutory_no_reconstructor,
     pow_rotation,
+    self_adjoint,
 )
+from pennylane.operation import Operator
 from pennylane.typing import TensorLike
 from pennylane.wires import WiresLike
 
@@ -1086,7 +1088,8 @@ class EchoedConditionalDisplacement(HybridOperation, FockRepresentation):
 
     .. math::
 
-        ECD(\alpha) = X~CD(\alpha/2)
+        ECD(\alpha) &= D(\alpha/2)\ket{1}\bra{0} + D(-\alpha/2)\ket{0}\bra{1} \\
+                    &= X~CD(\alpha/2)
 
     where :math:`CD(\alpha)` is the :py:class:`~.ConditionalDisplacement` gate
     (p. S9 of :footcite:p:`eickbusch2022fast`).
@@ -1128,12 +1131,17 @@ class EchoedConditionalDisplacement(HybridOperation, FockRepresentation):
     ):
         super().__init__(a, phi, wires=wires, id=id)
 
-    def pow(self, z: int | float):
-        a, phi = self.data
-        return [EchoedConditionalDisplacement(a * z, phi, self.wires)]  # ty:ignore[unsupported-operator]
+    def pow(self, z: int | float) -> list[Operator]:
+        # ECD is involutory
+        z_mod2 = z % 2
+        if abs(z_mod2) < 1e-10:
+            return [qp.Identity(self.wires)]
+
+        return super().pow(z_mod2)
 
     def adjoint(self):
-        return [EchoedConditionalDisplacement(-self.data[0], self.data[1], self.wires)]  # ty:ignore[unsupported-operator]
+        # self-adjoint
+        return EchoedConditionalDisplacement(*self.data, wires=self.wires)
 
     def simplify(self):
         a, phi = self.data[0], self.data[1] % (2 * math.pi)  # ty:ignore[unsupported-operator]
@@ -1150,12 +1158,10 @@ class EchoedConditionalDisplacement(HybridOperation, FockRepresentation):
 
     @staticmethod
     def compute_fock_matrix(wire_dims: tuple[int, ...], a, phi) -> TensorLike:  # ty:ignore[invalid-method-override]
-        dims = dict(enumerate(wire_dims))
-        cd = CD.compute_fock_matrix(wire_dims, a / 2, phi)
-        x = qp.X.compute_matrix()
-        x = hl.math.asarray(x, like=a)
-        x = hl.math.expand_matrix(x, (0,), wire_dims=dims, wire_order=(0, 1))
-        return x @ cd
+        d = hl.D.compute_fock_matrix(wire_dims[1:], a / 2, phi)
+        proj = hl.math.array([[0, 0], [1, 0]], like=a) # |1><0|
+        mat = hl.math.kron(proj, d)
+        return mat + hl.math.dag(mat)
 
 
 @qp.register_resources({ConditionalDisplacement: 1, qp.X: 1})
@@ -1164,14 +1170,9 @@ def _ecd_decomp(a, phi, wires, **_):
     qp.X(wires[0])
 
 
-@qp.register_resources({EchoedConditionalDisplacement: 1})
-def _pow_ecd(a, phi, wires, z, **_):
-    EchoedConditionalDisplacement(z * a, phi, wires=wires)
-
-
 qp.add_decomps(EchoedConditionalDisplacement, _ecd_decomp)
-qp.add_decomps("Adjoint(EchoedConditionalDisplacement)", adjoint_rotation)
-qp.add_decomps("Pow(EchoedConditionalDisplacement)", _pow_ecd)
+qp.add_decomps("Adjoint(EchoedConditionalDisplacement)", self_adjoint)
+qp.add_decomps("Pow(EchoedConditionalDisplacement)", pow_involutory_no_reconstructor)
 
 ECD = EchoedConditionalDisplacement
 r"""Echoed-conditional displacement (ECD) gate

--- a/src/hybridlane/ops/hybrid/parametric_ops_single_qumode.py
+++ b/src/hybridlane/ops/hybrid/parametric_ops_single_qumode.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # ruff: noqa: D107, D102
 r"""Hybrid CV-DV operations acting on a single qumode"""
+
 import math
 from typing import ClassVar
 
@@ -1159,7 +1160,7 @@ class EchoedConditionalDisplacement(HybridOperation, FockRepresentation):
     @staticmethod
     def compute_fock_matrix(wire_dims: tuple[int, ...], a, phi) -> TensorLike:  # ty:ignore[invalid-method-override]
         d = hl.D.compute_fock_matrix(wire_dims[1:], a / 2, phi)
-        proj = hl.math.array([[0, 0], [1, 0]], like=a) # |1><0|
+        proj = hl.math.array([[0, 0], [1, 0]], like=a)  # |1><0|
         mat = hl.math.kron(proj, d)
         return mat + hl.math.dag(mat)
 

--- a/test/ops/hybrid/test_parametric_ops_single_qumode.py
+++ b/test/ops/hybrid/test_parametric_ops_single_qumode.py
@@ -970,26 +970,20 @@ class TestEchoedConditionalDisplacement:
     def test_cd_decomp(self):
         tape = QuantumScript([hl.ECD(0.4, 0.123, wires=[0, 1])])
         [new_tape], _ = qp.decompose(tape, gate_set={hl.CD, qp.X})
-        expected_tape = QuantumScript([
-            hl.CD(0.2, 0.123, wires=(0, 1)),
-            qp.X(0)
-        ])
+        expected_tape = QuantumScript([hl.CD(0.2, 0.123, wires=(0, 1)), qp.X(0)])
         check_tapes_approx(new_tape, expected_tape)
 
     def test_adjoint_decomp(self):
         tape = QuantumScript([qp.adjoint(hl.ECD(0.4, 0.123, wires=[0, 1]))])
         [new_tape], _ = qp.decompose(tape, gate_set={hl.ECD})
-        expected_tape = QuantumScript([
-            hl.ECD(0.4, 0.123, wires=(0, 1))
-        ])
+        expected_tape = QuantumScript([hl.ECD(0.4, 0.123, wires=(0, 1))])
         check_tapes_approx(new_tape, expected_tape)
 
     def test_pow_involutory_decomp(self):
-        tape = QuantumScript([
-            qp.pow(hl.ECD(0.4, 0.123, wires=[0, 1]), 2)
-        ])
+        tape = QuantumScript([qp.pow(hl.ECD(0.4, 0.123, wires=[0, 1]), 2)])
         [new_tape], _ = qp.decompose(tape)
         assert new_tape.operations == []
+
 
 def check_tapes_approx(tape1, tape2):
     """Check if two tapes are approximately equal."""

--- a/test/ops/hybrid/test_parametric_ops_single_qumode.py
+++ b/test/ops/hybrid/test_parametric_ops_single_qumode.py
@@ -4,6 +4,7 @@ import math
 
 import pennylane as qp
 import pytest
+from pennylane.tape.qscript import QuantumScript
 
 import hybridlane as hl
 
@@ -887,50 +888,58 @@ class TestEchoedConditionalDisplacement:
 
     def test_adjoint(self):
         op = hl.EchoedConditionalDisplacement(0.5, 0, wires=[0, 1])
-        adj_op = op.adjoint()[0]
-        assert adj_op.parameters == [-0.5, 0]
+        adj_op = op.adjoint()
+        assert adj_op.parameters == [0.5, 0]
 
     def test_pow(self):
         op = hl.EchoedConditionalDisplacement(0.5, 0.123, wires=[0, 1])
         pow_op = op.pow(4)[0]
-        assert pow_op.parameters == [2, 0.123]
+        assert pow_op == qp.Identity(pow_op.wires)
+
+        pow_op = op.pow(3)[0]
+        assert isinstance(pow_op, hl.EchoedConditionalDisplacement)
+        assert pow_op.parameters == [0.5, 0.123]
 
     def test_simplify(self):
         op = hl.EchoedConditionalDisplacement(0, 0.123, wires=[0, 1])
         simplified_op = op.simplify()
         assert simplified_op == qp.X(0)
 
+        op = hl.ECD(0.456, 0.123 + 2 * math.pi, wires=[0, 1])
+        simplified_op = op.simplify()
+        assert simplified_op.parameters == pytest.approx((0.456, 0.123))
+
     def test_label(self):
         op = hl.EchoedConditionalDisplacement(0.5, 0, wires=[0, 1])
         assert op.label() == "ECD"
 
-    def test_fock_matrix_zero(self):
+    @pytest.mark.all_interfaces
+    def test_fock_matrix_zero(self, like):
         # CD(0) = I, so ECD(0) = X @ I = X ⊗ I_{qumode}.
-        op = hl.EchoedConditionalDisplacement(0.0, 0.0, wires=[0, 1])
+        params = hl.math.zeros(2, like=like)
+        op = hl.EchoedConditionalDisplacement(*params, wires=[0, 1])
         dim = 4
         matrix = op.fock_matrix({0: 2, 1: dim})
         # X ⊗ I_{dim}
         x_mat = qp.X.compute_matrix()
-        eye_dim = hl.math.eye(dim)
+        eye_dim = hl.math.eye(dim, like=like)
         expected = hl.math.kron(x_mat, eye_dim)
         assert matrix == pytest.approx(expected, abs=1e-6)
 
-    def test_fock_matrix_unitary(self):
-        op = hl.EchoedConditionalDisplacement(0.3, 0.5, wires=[0, 1])
+    @pytest.mark.all_interfaces
+    def test_fock_matrix_unitary(self, like):
+        params = hl.math.asarray([0.3, 0.5], like=like)
+        op = hl.EchoedConditionalDisplacement(*params, wires=[0, 1])
         matrix = op.fock_matrix({0: 2, 1: 6})
-        eye = hl.math.eye(12)
+        eye = hl.math.eye(12, like=like)
         assert matrix @ hl.math.dag(matrix) == pytest.approx(eye, abs=1e-6)
 
-    @pytest.mark.jax
-    def test_fock_matrix_jax(self):
-        import jax.numpy as jnp
-
-        a = jnp.array(0.3)
-        phi = jnp.array(0.5)
-        op = hl.EchoedConditionalDisplacement(a, phi, wires=[0, 1])  # ty:ignore[invalid-argument-type]
+    @pytest.mark.all_interfaces
+    def test_fock_matrix_involutory(self, like):
+        params = hl.math.asarray([0.3, 0.5], like=like)
+        op = hl.EchoedConditionalDisplacement(*params, wires=[0, 1])
         matrix = op.fock_matrix({0: 2, 1: 6})
-        eye = hl.math.eye(12, like="jax")
-        assert matrix @ hl.math.dag(matrix) == pytest.approx(eye, abs=1e-6)
+        assert hl.math.dag(matrix) == pytest.approx(matrix, abs=1e-6)
 
     @pytest.mark.jax
     def test_fock_matrix_jit(self):
@@ -957,3 +966,35 @@ class TestEchoedConditionalDisplacement:
         grad_fn = hl.math.jacobian(f)
         grad = grad_fn(x)
         assert not jnp.any(jnp.isnan(grad))
+
+    def test_cd_decomp(self):
+        tape = QuantumScript([hl.ECD(0.4, 0.123, wires=[0, 1])])
+        [new_tape], _ = qp.decompose(tape, gate_set={hl.CD, qp.X})
+        expected_tape = QuantumScript([
+            hl.CD(0.2, 0.123, wires=(0, 1)),
+            qp.X(0)
+        ])
+        check_tapes_approx(new_tape, expected_tape)
+
+    def test_adjoint_decomp(self):
+        tape = QuantumScript([qp.adjoint(hl.ECD(0.4, 0.123, wires=[0, 1]))])
+        [new_tape], _ = qp.decompose(tape, gate_set={hl.ECD})
+        expected_tape = QuantumScript([
+            hl.ECD(0.4, 0.123, wires=(0, 1))
+        ])
+        check_tapes_approx(new_tape, expected_tape)
+
+    def test_pow_involutory_decomp(self):
+        tape = QuantumScript([
+            qp.pow(hl.ECD(0.4, 0.123, wires=[0, 1]), 2)
+        ])
+        [new_tape], _ = qp.decompose(tape)
+        assert new_tape.operations == []
+
+def check_tapes_approx(tape1, tape2):
+    """Check if two tapes are approximately equal."""
+    for op1, op2 in zip(tape1.operations, tape2.operations, strict=True):
+        assert type(op1) is type(op2)
+        assert op1.wires == op2.wires
+        for p1, p2 in zip(op1.parameters, op2.parameters, strict=True):
+            assert hl.math.allclose(p1, p2)


### PR DESCRIPTION
This makes the ECD gate self-adjoint, which changes the behavior of the `adjoint()`,
`pow()` and corresponding decomposition methods. Also changes the `fock_matrix`
implementation to have fewer steps, hopefully leading to a speedup in simulation.
